### PR TITLE
Fix Express example build/start scripts

### DIFF
--- a/examples/node-express/package.json
+++ b/examples/node-express/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "type": "module",
   "scripts": {
-    "build": "marko-run build src/index.ts",
+    "build": "marko-run build",
     "dev": "marko-run -- tsx src/index.ts",
-    "start": "marko-run preview src/index.ts"
+    "start": "marko-run preview"
   },
   "devDependencies": {
     "@marko/compiler": "^5.22.6",


### PR DESCRIPTION
## Description

Fix the build & start script in node express example package.json

## Motivation and Context

`npm run build` and `npm run start` scripts don't work. They return an error:

```
Error [RollupError]: No Marko files were found when bundling the server in linked mode.
```

The change has been tested locally and both commands work after the fix.

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->