### PR TITLE
fix: flush contents earlier, at the expense of compression sizes

### DIFF
--- a/packages/run/src/adapter/default-entry.mjs
+++ b/packages/run/src/adapter/default-entry.mjs
@@ -5,6 +5,7 @@ import { createMiddleware } from "@marko/run/adapter/middleware";
 import { fetch } from "@marko/run/router";
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
+import zlib from 'zlib';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -12,6 +13,7 @@ const { PORT = 3456 } = process.env;
 
 const middleware = createMiddleware(fetch);
 const compress = compression({
+  flush: zlib.constants.Z_PARTIAL_FLUSH,
   threshold: 500,
 });
 const staticServe = createStaticServe(__dirname, {


### PR DESCRIPTION
## Description

The default compression settings favour higher compression over lower latency. We should flip this around.

See https://markojs.com/docs/troubleshooting-streaming/

## Motivation and Context

I noticed some of my fast `<await>` were not appearing until much later. This allows my faster data lookups to be flushed earlier.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

I don't think the above checklist are relevant (?)