### PR TITLE
feat: use vite to load custom dev entries

### DIFF
--- a/examples/meta-router/package.json
+++ b/examples/meta-router/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "marko-run build src/index.ts",
-    "dev": "marko-run -- tsx src/index.ts",
+    "dev": "marko-run src/index.ts",
     "start": "marko-run preview src/index.ts"
   },
   "devDependencies": {

--- a/examples/node-express/package.json
+++ b/examples/node-express/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "marko-run build src/index.ts",
-    "dev": "marko-run -- tsx src/index.ts",
+    "dev": "marko-run src/index.ts",
     "start": "marko-run preview src/index.ts"
   },
   "devDependencies": {

--- a/examples/node-express/tsconfig.json
+++ b/examples/node-express/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["src/**/*", "vite.config.ts", ".marko-run/*"],
   "compilerOptions": {
     "rootDir": "./",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "noImplicitOverride": false
   }
 }

--- a/packages/adapters/node/src/middleware.ts
+++ b/packages/adapters/node/src/middleware.ts
@@ -65,9 +65,8 @@ export const matchMiddleware = asyncMiddleware(async () => {
   };
 
   if (process.env.NODE_ENV !== "production") {
-    const { createViteDevMiddleware } = await import("@marko/run/adapter");
-    const { createServer } = await import("vite");
-    const devServer = await createServer({
+    const { createViteDevMiddleware, createViteDevServer } = await import("@marko/run/adapter");
+    const devServer = await createViteDevServer({
       appType: "custom",
       server: { middlewareMode: true },
     });
@@ -99,8 +98,8 @@ export const routerMiddleware = asyncMiddleware(async () => {
 
 export const importRouterMiddleware = asyncMiddleware(async () => {
   if (process.env.NODE_ENV !== "production") {
-    const { createServer } = await import("vite");
-    const devServer = await createServer({
+    const { createViteDevServer } = await import("@marko/run/adapter");
+    const devServer = await createViteDevServer({
       appType: "custom",
       server: { middlewareMode: true },
     });

--- a/packages/run/scripts/build.ts
+++ b/packages/run/scripts/build.ts
@@ -52,7 +52,12 @@ await Promise.all([
     format: "esm",
     outExtension: { ".js": ".mjs" },
   }),
-  copy("cli/default.config.mjs", "adapter/default-entry.mjs", 'components'),
+  copy(
+    "cli/default.config.mjs",
+    "adapter/default-entry.mjs",
+    "adapter/load-dev-worker.mjs",
+    "components"
+  ),
 ]);
 
 async function copy(...items: ([string, string] | [string] | string)[]) {

--- a/packages/run/src/__tests__/fixtures/node-adapter-express-match/test.config.ts
+++ b/packages/run/src/__tests__/fixtures/node-adapter-express-match/test.config.ts
@@ -1,2 +1,1 @@
 export const entry = 'src/index.ts';
-export const dev_cmd = `tsx ${entry}`;

--- a/packages/run/src/__tests__/fixtures/node-adapter-express/test.config.ts
+++ b/packages/run/src/__tests__/fixtures/node-adapter-express/test.config.ts
@@ -1,2 +1,1 @@
 export const entry = 'src/index.ts';
-export const dev_cmd = `tsx ${entry}`;

--- a/packages/run/src/adapter/index.ts
+++ b/packages/run/src/adapter/index.ts
@@ -1,10 +1,22 @@
 import path from "path";
 import { fileURLToPath } from "url";
+import type { Address, Worker } from "cluster";
 import type { Adapter } from "../vite";
 import { createDevServer } from "./dev-server";
 import type { AddressInfo } from "net";
-import { loadEnv, spawnServer, type SpawnedServer } from "../vite/utils/server";
-export { createDevServer, createViteDevMiddleware } from "./dev-server";
+import {
+  loadEnv,
+  spawnServer,
+  type SpawnedServer,
+  spawnServerWorker,
+} from "../vite/utils/server";
+
+export {
+  activeDevServers,
+  createDevServer,
+  createViteDevServer,
+  createViteDevMiddleware,
+} from "./dev-server";
 export type { Adapter, SpawnedServer };
 export type { NodePlatformInfo } from "./middleware";
 
@@ -13,23 +25,70 @@ import parseNodeArgs from "parse-node-args";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
+const defaultEntry = path.join(__dirname, "default-entry");
+const loadDevWorker = path.join(__dirname, "load-dev-worker.mjs");
+
 export default function adapter(): Adapter {
   return {
     name: "base-adapter",
 
     async getEntryFile() {
-      const entry = path.join(__dirname, "default-entry");
-      return entry;
+      return defaultEntry;
     },
 
-    async startDev(config, { port = 3000, envFile }) {
-      const { root, configFile } = config;
-      envFile && (await loadEnv(envFile));
+    async startDev(entry, config, options) {
+      const { port = 3000, envFile } = options;
 
-      const devServer = await createDevServer({
-        root,
-        configFile,
-      });
+      if (entry) {
+        const { nodeArgs } = parseNodeArgs(options.args);
+        let worker: Worker;
+
+        async function start() {
+          const nextWorker = await spawnServerWorker(
+            loadDevWorker,
+            nodeArgs,
+            port,
+            envFile
+          );
+
+          nextWorker
+            .on("message", (messsage) => {
+              if (messsage === "restart") {
+                start();
+              }
+            })
+            .send({ type: "start", entry, config });
+
+          await waitForWorker(nextWorker, port);
+
+          if (worker) {
+            const prevWorker = worker;
+            let timeout: any;
+            worker.once("disconnect", () => {
+              clearTimeout(timeout);
+            });
+            worker.send({ type: "shutdown" });
+            worker.disconnect();
+            timeout = setTimeout(() => {
+              prevWorker.kill();
+            }, 2000);
+          }
+
+          worker = nextWorker;
+        }
+
+        await start();
+
+        return {
+          port,
+          close() {
+            worker.kill();
+          },
+        };
+      }
+
+      const devServer = await createDevServer(config);
+      envFile && (await loadEnv(envFile));
 
       return new Promise<SpawnedServer>((resolve) => {
         const listener = devServer.middlewares.listen(port, () => {
@@ -48,10 +107,22 @@ export default function adapter(): Adapter {
     async startPreview(entry, options) {
       const { port, envFile } = options;
       const { nodeArgs } = parseNodeArgs(options.args);
-      const args = [...nodeArgs, entry]
-      const server = await spawnServer('node', args, port, envFile);
+      const args = [...nodeArgs, entry];
+      const server = await spawnServer("node", args, port, envFile);
       console.log(`Preview server started: http://localhost:${server.port}`);
       return server;
     },
   };
+}
+
+async function waitForWorker(worker: Worker, port: number) {
+  return new Promise<void>((resolve) => {
+    function listening(address: Address) {
+      if (address.port === port) {
+        worker.off("listening", listening);
+        resolve();
+      }
+    }
+    worker.on("listening", listening);
+  });
 }

--- a/packages/run/src/adapter/load-dev-worker.mjs
+++ b/packages/run/src/adapter/load-dev-worker.mjs
@@ -1,0 +1,37 @@
+import { createServer } from "vite";
+
+let activeDevServers;
+
+process
+  .on("message", (message) => {
+    switch (message.type) {
+      case "start":
+        return start(message.entry, message.config);
+      case "shutdown":
+        return shutdown();
+    }
+  })
+  .send("ready");
+
+async function start(entry, config) {
+  let changed = false;
+  const loader = await createServer(config);
+  ({ activeDevServers } = await loader.ssrLoadModule("@marko/run/adapter"));
+  await loader.ssrLoadModule(entry);
+
+  loader.watcher.on("change", (path) => {
+    if (!changed && loader.moduleGraph.getModulesByFile(path)) {
+      changed = true;
+      process.send("restart");
+    }
+  });
+}
+
+function shutdown() {
+  if (activeDevServers) {
+    for (const devServer of activeDevServers) {
+      devServer.ws.send({ type: "full-reload" });
+    }
+    activeDevServers.clear();
+  }
+}

--- a/packages/run/src/cli/commands.ts
+++ b/packages/run/src/cli/commands.ts
@@ -11,7 +11,7 @@ import {
 } from "../vite/utils/config";
 import type { Adapter } from "../vite";
 import { MemoryStore } from "@marko/vite";
-import { type SpawnedServer, spawnServer } from "../vite/utils/server";
+import type { SpawnedServer } from "../vite/utils/server";
 import { resolveAdapter as pluginResolveAdapter } from "../vite/plugin";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
@@ -66,7 +66,7 @@ export async function preview(
 }
 
 export async function dev(
-  cmd: string | undefined,
+  entry: string | undefined,
   cwd: string,
   configFile: string,
   port?: number,
@@ -85,28 +85,25 @@ export async function dev(
     envFile = path.resolve(cwd, envFile);
   }
 
-  if (cmd) {
-    return await spawnServer(cmd, args, port, envFile, cwd);
-  } else {
-    const adapter = await resolveAdapter(resolvedConfig);
-    if (!adapter) {
-      throw new Error(
-        "No adapter specified for 'dev' command without custom target" // Would the user know what a target is if presented with this error?
-      );
-    } else if (!adapter.startDev) {
-      throw new Error(
-        `Adapter '${adapter.name}' does not support 'serve' command`
-      );
-    }
-    const options = {
-      cwd,
-      args,
-      port,
-      envFile,
-    };
-
-    return await adapter.startDev({ root: cwd, configFile }, options);
+  const adapter = await resolveAdapter(resolvedConfig);
+  if (!adapter) {
+    throw new Error(
+      "No adapter specified for 'dev' command without custom target" // Would the user know what a target is if presented with this error?
+    );
+  } else if (!adapter.startDev) {
+    throw new Error(
+      `Adapter '${adapter.name}' does not support 'serve' command`
+    );
   }
+
+  const options = {
+    cwd,
+    args,
+    port,
+    envFile,
+  };
+
+  return await adapter.startDev(entry, { root: cwd, configFile }, options);
 }
 
 export async function build(

--- a/packages/run/src/runtime/index.ts
+++ b/packages/run/src/runtime/index.ts
@@ -1,5 +1,7 @@
-import type { HandlerLike, ParamsObject, Route as AnyRoute, Context as AnyContext } from "./types";
+import type { HandlerLike, ParamsObject, Route as AnyRoute, Context as AnyContext, RuntimeModule } from "./types";
 declare global {
+  var __marko_run__: RuntimeModule;
+
   namespace MarkoRun {
     const NotHandled: unique symbol;
     const NotMatched: unique symbol;

--- a/packages/run/src/runtime/router.ts
+++ b/packages/run/src/runtime/router.ts
@@ -1,11 +1,17 @@
 import type { RuntimeModule } from "./types";
 
-function notImplemented(): never {
-  throw new Error(
-    "This should have been replaced by the @marko/run plugin at build/dev time"
-  );
+function fromRuntime<T extends 'fetch' | 'match' | 'invoke'>(name: T): RuntimeModule[T] {
+  return (...args: any[]) => {
+    const runtime = globalThis.__marko_run__;
+    if (!runtime) {
+      throw new Error(
+        "This should have been replaced by the @marko/run plugin at build/dev time"
+      );
+    }
+    return (runtime[name] as any)(...args)
+  }
 }
 
-export const fetch = notImplemented as RuntimeModule['fetch'];
-export const match = notImplemented as RuntimeModule['match'];
-export const invoke = notImplemented as RuntimeModule['invoke'];
+export const fetch = fromRuntime('fetch');
+export const match = fromRuntime('match');
+export const invoke = fromRuntime('invoke');

--- a/packages/run/src/vite/__tests__/fixtures/build-routes/__snapshots__/build-routes.expected.router.js
+++ b/packages/run/src/vite/__tests__/fixtures/build-routes/__snapshots__/build-routes.expected.router.js
@@ -20,6 +20,8 @@ const page500ResponseInit = {
   headers: { "content-type": "text/html;charset=UTF-8" },
 };
 
+globalThis.__marko_run__ = { match, fetch, invoke };
+    
 export function match(method, pathname) {
 	if (!pathname) {
     pathname = '/';

--- a/packages/run/src/vite/__tests__/fixtures/nested-dynamic/__snapshots__/nested-dynamic.expected.router.js
+++ b/packages/run/src/vite/__tests__/fixtures/nested-dynamic/__snapshots__/nested-dynamic.expected.router.js
@@ -2,6 +2,8 @@
 import { NotHandled, NotMatched, createContext } from 'virtual:marko-run/internal';
 import { get1 } from 'virtual:marko-run/__marko-run__route__foo__$__bar__$__baz__$__$.js';
 
+globalThis.__marko_run__ = { match, fetch, invoke };
+    
 export function match(method, pathname) {
 	if (!pathname) {
     pathname = '/';

--- a/packages/run/src/vite/__tests__/fixtures/uri-encoded/__snapshots__/uri-encoded.expected.router.js
+++ b/packages/run/src/vite/__tests__/fixtures/uri-encoded/__snapshots__/uri-encoded.expected.router.js
@@ -2,6 +2,8 @@
 import { NotHandled, NotMatched, createContext } from 'virtual:marko-run/internal';
 import { get1 } from 'virtual:marko-run/__marko-run__route__a2fb2fc__$.js';
 
+globalThis.__marko_run__ = { match, fetch, invoke };
+    
 export function match(method, pathname) {
 	if (!pathname) {
     pathname = '/';

--- a/packages/run/src/vite/codegen/index.ts
+++ b/packages/run/src/vite/codegen/index.ts
@@ -275,7 +275,9 @@ export function renderRouter(
   }
 
   writer
-    .writeLines('')
+    .writeLines(`
+globalThis.__marko_run__ = { match, fetch, invoke };
+    `)
     .writeBlockStart(`export function match(method, pathname) {`)
     .writeLines(
       `if (!pathname) {

--- a/packages/run/src/vite/types.ts
+++ b/packages/run/src/vite/types.ts
@@ -31,7 +31,7 @@ export interface Adapter {
   pluginOptions?(options: Options): Promise<Options> | Options | undefined;
   viteConfig?(config: UserConfig): Promise<UserConfig> | UserConfig | undefined;
   getEntryFile?(): Promise<string> | string;
-  startDev?(config: InlineConfig, options: StartDevOptions): Promise<SpawnedServer> | SpawnedServer;
+  startDev?(entry: string | undefined, config: InlineConfig, options: StartDevOptions): Promise<SpawnedServer> | SpawnedServer;
   startPreview?(entry: string | undefined, options: StartPreviewOptions): Promise<SpawnedServer> | SpawnedServer;
   buildEnd?(config: ResolvedConfig, routes: Route[], builtEntries: string[], sourceEntries: string[]): Promise<void> | void;
   typeInfo?(writer: (data: string) => void): Promise<string> | string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR changes the way the dev command works. Previously, if a custom entry file was specified, the CLI spawned a new node process and expected the file to be runnable with node. You could also specify a command (eg. `tsx`) to load the file. All of this completely side-stepped the adapter and was less than ideal. With this PR:
- Entry file will be passed to the adapter's `startDev` method
- Base adapter (which all the others currently use for dev) will start a new process and load the file with Vite. This means any file that Vite can process can be used as an entry.

This PR also makes the @marko/run runtime available to modules which were not processed by Vite as long as the runtime was previously loaded through Vite.

<!--- Describe your changes in detail.  Include the package name if applicable. -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [X] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->