### PR TITLE
Normalize the routes path

### DIFF
--- a/packages/run/src/vite/plugin.ts
+++ b/packages/run/src/vite/plugin.ts
@@ -114,7 +114,7 @@ export default function markoRun(opts: Options = {}): Plugin[] {
 
       const data = await renderRouteTypeInfo(
         routes,
-        path.relative(typesDir, resolvedRoutesDir),
+        normalizePath(path.relative(typesDir, resolvedRoutesDir)),
         adapter
       );
 


### PR DESCRIPTION
Closes: https://github.com/marko-js/run/issues/22

Using `path.posix.relative` is not an option because it returns the wrong paths on Windows. See:
* https://github.com/nodejs/node/issues/13887
* https://github.com/nodejs/node/pull/13738

It doesn't look like we have any CI, it might be worth using Github Actions and running tests on windows and ubuntu runners to catch issues like this in the future?