### PR TITLE
Fixes

### DIFF
--- a/packages/run/src/__tests__/fixtures/basic-cookies/test.config.ts
+++ b/packages/run/src/__tests__/fixtures/basic-cookies/test.config.ts
@@ -5,6 +5,7 @@ export async function steps() {
   const actual: string[] = [];
   for (const { name, value } of await response!.headersArray()) {
     if (name === 'set-cookie') {
+      if (value.startsWith('hmr-client-id=')) continue;
       actual.push(value)
     }
   }

--- a/packages/run/src/vite/__tests__/fixtures/basic/__snapshots__/basic.expected.routetypes.d.ts
+++ b/packages/run/src/vite/__tests__/fixtures/basic/__snapshots__/basic.expected.routetypes.d.ts
@@ -16,9 +16,6 @@ declare module "@marko/run" {
 }
 
 declare module "./+page.marko" {
-  export interface Input {
-    renderBody: Marko.Body;
-  }
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
     export type Route = Run.Routes["/"];

--- a/packages/run/src/vite/__tests__/fixtures/build-routes/__snapshots__/build-routes.expected.routetypes.d.ts
+++ b/packages/run/src/vite/__tests__/fixtures/build-routes/__snapshots__/build-routes.expected.routetypes.d.ts
@@ -122,9 +122,6 @@ declare module "./_protected/_home/notes/$id/+middleware" {
 }
 
 declare module "./_protected/_home/+page.marko" {
-  export interface Input {
-    renderBody: Marko.Body;
-  }
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
     export type Route = Run.Routes["/"];
@@ -135,9 +132,6 @@ declare module "./_protected/_home/+page.marko" {
 }
 
 declare module "./_protected/_home/new/+page.marko" {
-  export interface Input {
-    renderBody: Marko.Body;
-  }
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
     export type Route = Run.Routes["/new"];
@@ -148,9 +142,6 @@ declare module "./_protected/_home/new/+page.marko" {
 }
 
 declare module "./_protected/_home/notes/$id/+page.marko" {
-  export interface Input {
-    renderBody: Marko.Body;
-  }
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
     export type Route = Run.Routes["/notes/:id"];
@@ -161,9 +152,6 @@ declare module "./_protected/_home/notes/$id/+page.marko" {
 }
 
 declare module "./my/+page.marko" {
-  export interface Input {
-    renderBody: Marko.Body;
-  }
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
     export type Route = Run.Routes["/my"];
@@ -200,7 +188,6 @@ declare module "./_protected/_home/+layout.marko" {
 }
 
 declare module "./+404.marko" {
-  export interface Input {}
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
     export type Route = Run.Route;

--- a/packages/run/src/vite/__tests__/fixtures/flat-routes/__snapshots__/flat-routes.expected.routetypes.d.ts
+++ b/packages/run/src/vite/__tests__/fixtures/flat-routes/__snapshots__/flat-routes.expected.routetypes.d.ts
@@ -83,9 +83,6 @@ declare module "./$id,a.d+middleware.marko" {
 }
 
 declare module "./foo,$id,$$rest,+page.marko" {
-  export interface Input {
-    renderBody: Marko.Body;
-  }
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
     export type Route = Run.Routes["/"];
@@ -96,9 +93,6 @@ declare module "./foo,$id,$$rest,+page.marko" {
 }
 
 declare module "./foo,$id,$$rest,+page.marko" {
-  export interface Input {
-    renderBody: Marko.Body;
-  }
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
     export type Route = Run.Routes["/foo"];
@@ -109,9 +103,6 @@ declare module "./foo,$id,$$rest,+page.marko" {
 }
 
 declare module "./foo,$id,$$rest,+page.marko" {
-  export interface Input {
-    renderBody: Marko.Body;
-  }
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
     export type Route = Run.Routes["/:id"];
@@ -122,9 +113,6 @@ declare module "./foo,$id,$$rest,+page.marko" {
 }
 
 declare module "./foo,$id,$$rest,+page.marko" {
-  export interface Input {
-    renderBody: Marko.Body;
-  }
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
     export type Route = Run.Routes["/:rest*"];

--- a/packages/run/src/vite/__tests__/fixtures/nested-dynamic/__snapshots__/nested-dynamic.expected.routetypes.d.ts
+++ b/packages/run/src/vite/__tests__/fixtures/nested-dynamic/__snapshots__/nested-dynamic.expected.routetypes.d.ts
@@ -16,9 +16,6 @@ declare module "@marko/run" {
 }
 
 declare module "./foo/$fooId/bar/$bar Id/baz/$1bazId/$qux-Id/+page.marko" {
-  export interface Input {
-    renderBody: Marko.Body;
-  }
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
     export type Route = Run.Routes["/foo/:fooId/bar/:bar Id/baz/:1bazId/:qux-Id"];

--- a/packages/run/src/vite/__tests__/fixtures/optional-dynamic/__snapshots__/optional-dynamic.expected.routetypes.d.ts
+++ b/packages/run/src/vite/__tests__/fixtures/optional-dynamic/__snapshots__/optional-dynamic.expected.routetypes.d.ts
@@ -19,9 +19,6 @@ declare module "@marko/run" {
 }
 
 declare module "./$foo,/$bar,$$rest/+page.marko" {
-  export interface Input {
-    renderBody: Marko.Body;
-  }
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
     export type Route = Run.Routes["/:foo"];
@@ -32,9 +29,6 @@ declare module "./$foo,/$bar,$$rest/+page.marko" {
 }
 
 declare module "./$foo,/$bar,$$rest/+page.marko" {
-  export interface Input {
-    renderBody: Marko.Body;
-  }
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
     export type Route = Run.Routes["/:foo/:bar"];
@@ -45,9 +39,6 @@ declare module "./$foo,/$bar,$$rest/+page.marko" {
 }
 
 declare module "./$foo,/$bar,$$rest/+page.marko" {
-  export interface Input {
-    renderBody: Marko.Body;
-  }
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
     export type Route = Run.Routes["/:foo/:rest*"];
@@ -58,9 +49,6 @@ declare module "./$foo,/$bar,$$rest/+page.marko" {
 }
 
 declare module "./$foo,/$bar,$$rest/+page.marko" {
-  export interface Input {
-    renderBody: Marko.Body;
-  }
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
     export type Route = Run.Routes["/:rest*"];

--- a/packages/run/src/vite/__tests__/fixtures/optional-static/__snapshots__/optional-static.expected.routetypes.d.ts
+++ b/packages/run/src/vite/__tests__/fixtures/optional-static/__snapshots__/optional-static.expected.routetypes.d.ts
@@ -23,9 +23,6 @@ declare module "@marko/run" {
 }
 
 declare module "./foo,/bar,/,baz/+page.marko" {
-  export interface Input {
-    renderBody: Marko.Body;
-  }
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
     export type Route = Run.Routes["/"];
@@ -36,9 +33,6 @@ declare module "./foo,/bar,/,baz/+page.marko" {
 }
 
 declare module "./foo,/bar,/,baz/+page.marko" {
-  export interface Input {
-    renderBody: Marko.Body;
-  }
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
     export type Route = Run.Routes["/foo"];
@@ -49,9 +43,6 @@ declare module "./foo,/bar,/,baz/+page.marko" {
 }
 
 declare module "./foo,/bar,/,baz/+page.marko" {
-  export interface Input {
-    renderBody: Marko.Body;
-  }
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
     export type Route = Run.Routes["/foo/bar"];
@@ -62,9 +53,6 @@ declare module "./foo,/bar,/,baz/+page.marko" {
 }
 
 declare module "./foo,/bar,/,baz/+page.marko" {
-  export interface Input {
-    renderBody: Marko.Body;
-  }
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
     export type Route = Run.Routes["/foo/bar/baz"];
@@ -75,9 +63,6 @@ declare module "./foo,/bar,/,baz/+page.marko" {
 }
 
 declare module "./foo,/bar,/,baz/+page.marko" {
-  export interface Input {
-    renderBody: Marko.Body;
-  }
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
     export type Route = Run.Routes["/foo/baz"];
@@ -88,9 +73,6 @@ declare module "./foo,/bar,/,baz/+page.marko" {
 }
 
 declare module "./foo,/bar,/,baz/+page.marko" {
-  export interface Input {
-    renderBody: Marko.Body;
-  }
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
     export type Route = Run.Routes["/bar"];
@@ -101,9 +83,6 @@ declare module "./foo,/bar,/,baz/+page.marko" {
 }
 
 declare module "./foo,/bar,/,baz/+page.marko" {
-  export interface Input {
-    renderBody: Marko.Body;
-  }
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
     export type Route = Run.Routes["/bar/baz"];
@@ -114,9 +93,6 @@ declare module "./foo,/bar,/,baz/+page.marko" {
 }
 
 declare module "./foo,/bar,/,baz/+page.marko" {
-  export interface Input {
-    renderBody: Marko.Body;
-  }
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
     export type Route = Run.Routes["/baz"];

--- a/packages/run/src/vite/__tests__/fixtures/uri-encoded/__snapshots__/uri-encoded.expected.routetypes.d.ts
+++ b/packages/run/src/vite/__tests__/fixtures/uri-encoded/__snapshots__/uri-encoded.expected.routetypes.d.ts
@@ -16,9 +16,6 @@ declare module "@marko/run" {
 }
 
 declare module "./a%2Fb%2Fc/$%24id/+page.marko" {
-  export interface Input {
-    renderBody: Marko.Body;
-  }
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
     export type Route = Run.Routes["/a%2Fb%2Fc/:$id"];

--- a/packages/run/src/vite/codegen/index.ts
+++ b/packages/run/src/vite/codegen/index.ts
@@ -722,10 +722,6 @@ export async function renderRouteTypeInfo(
         writer,
         `${pathPrefix}/${page.relativePath}`,
         `Run.Routes[${routeType}]`,
-        `
-  export interface Input {
-    renderBody: Marko.Body;
-  }`
       );
     }
 
@@ -786,8 +782,6 @@ export async function renderRouteTypeInfo(
       writer,
       `${pathPrefix}/${routes.special["404"].page.relativePath}`,
       "Run.Route",
-      `
-  export interface Input {}`
     );
   }
 

--- a/packages/run/src/vite/plugin.ts
+++ b/packages/run/src/vite/plugin.ts
@@ -299,6 +299,18 @@ export default function markoRun(opts: Options = {}): Plugin[] {
               output: rollupOutputOptions,
             },
           },
+          resolve: isBuild
+            ? {
+                browserField: isSSRBuild ? false : undefined,
+                conditions: [
+                  isSSRBuild ? "node" : "browser",
+                  "import",
+                  "require",
+                  "production",
+                  "default",
+                ],
+              }
+            : undefined,
         };
 
         const adapterConfig = await adapter?.viteConfig?.(config);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Fix potential memory leak in dev mode where many event listeners were added to listen for web socket connections
- Fix potential memory leak where event handlers on the http socket don't get cleaned up
- Fix type generation for +page.marko which incorrectly required a `renderBody` in the `Input` type

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->