### PR TITLE
fix: improve param types within multi-route files

### DIFF
--- a/packages/run/src/runtime/types.ts
+++ b/packages/run/src/runtime/types.ts
@@ -1,6 +1,14 @@
 type Awaitable<T> = Promise<T> | T;
 type OneOrMany<T> = T | T[];
 type NoParams = {};
+type AllKeys<T> = T extends T ? keyof T : never;
+type Simplify<T> = T extends unknown ? { [K in keyof T]: T[K] } : never;
+type SuperSet<T, U extends T> = Simplify<
+  T & { [K in AllKeys<U> as K extends keyof T ? never : K]: undefined }
+>;
+type SuperSets<T, U extends T, K extends keyof T> = Omit<T, K> & {
+  [P in K]: SuperSet<T[P], U[P]>;
+};
 
 export interface Platform {}
 
@@ -14,10 +22,12 @@ export interface Context<TRoute extends Route = AnyRoute> {
   readonly serializedGlobals: Record<string, boolean>;
 }
 
-export type MultiRouteContext<TRoute extends Route> = TRoute extends any
-  ? Context<TRoute>
+export type MultiRouteContext<
+  TRoute extends Route,
+  _Preserved extends TRoute = TRoute
+> = TRoute extends any
+  ? Context<Simplify<SuperSets<TRoute, _Preserved, "params">>>
   : never;
-
 export type ParamsObject = Record<string, string>;
 export type InputObject = Record<PropertyKey, any>;
 export type NextFunction = () => Awaitable<Response>;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Improves the type for `params` on `MarkoRun.Context` (`$global`) within files that handle multiple routes such as middleware, layouts as well as pages and handlers when using a flat route that expands to more than one route.

Previously, params which were not on all handled routes would not be accessible on the params property unless you discriminated by route. Now these params will be potentially undefined and will narrow to undefined when discriminating by route.

<!--- Describe your changes in detail.  Include the package name if applicable. -->

## Motivation and Context

Fixes #45

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->