### PR TITLE
fix: body-parser overwrites req.body

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7559,7 +7559,7 @@
     },
     "packages/run": {
       "name": "@marko/run",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "MIT",
       "dependencies": {
         "@marko/vite": "^3",

--- a/packages/run/src/adapter/middleware.ts
+++ b/packages/run/src/adapter/middleware.ts
@@ -227,7 +227,9 @@ export function createMiddleware(
       body:
         req.method === "GET" || req.method === "HEAD"
           ? undefined
-          : (req as any as ReadableStream),
+          : typeof (req as any).body == "object"
+            ? JSON.stringify((req as any).body)
+            : (req as any as ReadableStream),
       // @ts-expect-error: Node requires this for streams
       duplex: "half",
       signal,


### PR DESCRIPTION
note: this requires a re-parse of sorts in the handler via something like `let data = await context.request.json();`

## Description

detecting when body-parser or similar libs have overwritten the req.body stream with a js object and converting it back into a string

## Motivation and Context

currently if you use express with body-parser it breaks marko run due to the unexpected object at req.body

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->