### PR TITLE
fix: not building production correctly

### DIFF
--- a/packages/run/src/cli/commands.ts
+++ b/packages/run/src/cli/commands.ts
@@ -148,7 +148,9 @@ export async function build(
   const root = cwd;
   const resolvedConfig = await resolveConfig(
     { root, configFile, logLevel: "silent" },
-    "build"
+    "build",
+    "production",
+    "production"
   );
   const adapter = await resolveAdapter(resolvedConfig);
 


### PR DESCRIPTION
## Description

Production builds contain debug code.

## Motivation and Context

Some debug code was making its way into my production build.

Using `@marko/vite@4.0.2` or earlier builds production bundles correctly.

I suspect that [this fix](https://github.com/marko-js/vite/commit/3aca2777444af5b6408d2f0dffd8b4b0840acf1f) revealed an underlying bug here, noticeable with `@marko/vite@4.0.3` onwards.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.