### PR TITLE
fix: node - ensure flush after res write

### DIFF
--- a/packages/run/src/adapter/middleware.ts
+++ b/packages/run/src/adapter/middleware.ts
@@ -236,10 +236,11 @@ async function writeResponse(
       if (done) {
         res.end();
         return;
-      } else if (!res.write(value)) {
-        res.once("drain", () => writeResponse(reader, res, controller));
-        return;
-      } else if ((res as any).flush) {
+      }
+      
+      res.write(value);
+      
+      if ((res as any).flush) {
         (res as any).flush();
       }
     }


### PR DESCRIPTION
No longer wait for 'drain' event and buffer in node instead

<!--- Provide a general summary of your changes in the Title above -->

## Description

In some situations, the Node response stream stops draining while writing from the WHATWG response and Marko Run does not correctly call `flush` on the Node response which is necessary when compression middleware is in use. This causes async flushes to get delayed until the next flush.

This change refactors the relevant code so we unconditionally call flush after calling write. Previously we were waiting for the 'drain' event from the writable (Node response) and resuming writing after that. It is my opinion this adds nothing - either we will be buffering in Marko or now in Node when the response stops draining. We have no way to signal this back-pressure to Marko to stop generating content.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->