### PR TITLE
docs(adapters): corrected the Netlify adapter install

### DIFF
--- a/packages/adapters/netlify/README.md
+++ b/packages/adapters/netlify/README.md
@@ -15,7 +15,7 @@ Preview and deploy [@marko/run](../serve/README.md) apps to Netlify Functions/Ed
 ## Intallation
 
 ```sh
-npm install @marko/run-adapter-static
+npm install @marko/run-adapter-netlify
 ```
 
 ## Usage


### PR DESCRIPTION
The docs for installing the Netlify adapter had the install of the static adapter.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->