### PR TITLE
fix: improve MarkoRun.route type to return the actual value passed

### DIFF
--- a/packages/run/src/runtime/types.ts
+++ b/packages/run/src/runtime/types.ts
@@ -215,10 +215,10 @@ export type AnyHandler<
 
 export type HandlerTypeFn<TRoute extends Route = AnyRoute> =
   0 extends HasAppData
-    ? <Params extends ParamsObject = ParamsObject, Meta = unknown>(
-        handler: HandlerLike<Route<Params, Meta>>
-      ) => HandlerLike<Route<Params, Meta>>
-    : (handler: HandlerLike<TRoute>) => HandlerLike<TRoute>;
+    ? <Params extends ParamsObject = ParamsObject, Meta = unknown, T extends HandlerLike<Route<Params, Meta>> = HandlerLike<Route<Params, Meta>>>(
+        handler: T
+      ) => T
+    : <T extends HandlerLike<TRoute>>(handler: T) => T;
 
 export type GetPaths = AppData extends { getPaths: infer T } ? T : string;
 export type PostPaths = AppData extends { postPaths: infer T } ? T : string;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`MarkoRun.route` is an identity function that is used to provide types to to users' middleware and handler functions. It accepts handler functions and arrays of handler functions. This change makes it generic to return the type of the actual object you passed.

<!--- Describe your changes in detail.  Include the package name if applicable. -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->