### PR TITLE
feat: deprecate MarkoRun.route

### DIFF
--- a/packages/run/src/__tests__/fixtures/basic-404/.marko-run/routes.d.ts
+++ b/packages/run/src/__tests__/fixtures/basic-404/.marko-run/routes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 
 
 declare module "@marko/run" {
@@ -21,6 +21,7 @@ declare module "../src/routes/+page.marko" {
     export type Route = Run.Routes["/"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -34,6 +35,7 @@ declare module "../src/routes/+layout.marko" {
     export type Route = Run.Routes["/"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -44,6 +46,7 @@ declare module "../src/routes/+404.marko" {
     export type Route = Run.Route;
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/__tests__/fixtures/basic-500/.marko-run/routes.d.ts
+++ b/packages/run/src/__tests__/fixtures/basic-500/.marko-run/routes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 
 
 declare module "@marko/run" {
@@ -21,6 +21,7 @@ declare module "../src/routes/+handler" {
     export type Route = Run.Routes["/"];
     export type Context = Run.MultiRouteContext<Route>;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -31,6 +32,7 @@ declare module "../src/routes/+page.marko" {
     export type Route = Run.Routes["/"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -44,6 +46,7 @@ declare module "../src/routes/+layout.marko" {
     export type Route = Run.Routes["/"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -57,6 +60,7 @@ declare module "../src/routes/+500.marko" {
     export type Route = globalThis.MarkoRun.Route;
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/__tests__/fixtures/basic-cookies/.marko-run/routes.d.ts
+++ b/packages/run/src/__tests__/fixtures/basic-cookies/.marko-run/routes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 
 
 declare module "@marko/run" {
@@ -21,6 +21,7 @@ declare module "../src/routes/+middleware" {
     export type Route = Run.Routes["/"];
     export type Context = Run.MultiRouteContext<Route>;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -31,6 +32,7 @@ declare module "../src/routes/+page.marko" {
     export type Route = Run.Routes["/"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/__tests__/fixtures/basic-handler/.marko-run/routes.d.ts
+++ b/packages/run/src/__tests__/fixtures/basic-handler/.marko-run/routes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 
 
 declare module "@marko/run" {
@@ -21,6 +21,7 @@ declare module "../src/routes/+handler" {
     export type Route = Run.Routes["/"];
     export type Context = Run.MultiRouteContext<Route>;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -31,6 +32,7 @@ declare module "../src/routes/+page.marko" {
     export type Route = Run.Routes["/"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/__tests__/fixtures/basic-layout/.marko-run/routes.d.ts
+++ b/packages/run/src/__tests__/fixtures/basic-layout/.marko-run/routes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 
 
 declare module "@marko/run" {
@@ -21,6 +21,7 @@ declare module "../src/routes/+page.marko" {
     export type Route = Run.Routes["/"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -34,6 +35,7 @@ declare module "../src/routes/+layout.marko" {
     export type Route = Run.Routes["/"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/__tests__/fixtures/basic-middleware/.marko-run/routes.d.ts
+++ b/packages/run/src/__tests__/fixtures/basic-middleware/.marko-run/routes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 
 
 declare module "@marko/run" {
@@ -21,6 +21,7 @@ declare module "../src/routes/+middleware" {
     export type Route = Run.Routes["/"];
     export type Context = Run.MultiRouteContext<Route>;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -31,6 +32,7 @@ declare module "../src/routes/+page.marko" {
     export type Route = Run.Routes["/"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/__tests__/fixtures/basic-page/.marko-run/routes.d.ts
+++ b/packages/run/src/__tests__/fixtures/basic-page/.marko-run/routes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 
 
 declare module "@marko/run" {
@@ -21,6 +21,7 @@ declare module "../src/routes/+page.marko" {
     export type Route = Run.Routes["/"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/__tests__/fixtures/basic-redirect/.marko-run/routes.d.ts
+++ b/packages/run/src/__tests__/fixtures/basic-redirect/.marko-run/routes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 
 
 declare module "@marko/run" {
@@ -22,6 +22,7 @@ declare module "../src/routes/+handler" {
     export type Route = Run.Routes["/"];
     export type Context = Run.MultiRouteContext<Route>;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -32,6 +33,7 @@ declare module "../src/routes/other+page.marko" {
     export type Route = Run.Routes["/other"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/__tests__/fixtures/config-override/.marko-run/routes.d.ts
+++ b/packages/run/src/__tests__/fixtures/config-override/.marko-run/routes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 
 
 declare module "@marko/run" {
@@ -21,6 +21,7 @@ declare module "../src/routes/+page.marko" {
     export type Route = Run.Routes["/"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/__tests__/fixtures/dynamic-nested/.marko-run/routes.d.ts
+++ b/packages/run/src/__tests__/fixtures/dynamic-nested/.marko-run/routes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 
 
 declare module "@marko/run" {
@@ -21,6 +21,7 @@ declare module "../src/routes/foo/$fooId/bar/$barId/+page.marko" {
     export type Route = Run.Routes["/foo/:fooId/bar/:barId"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/__tests__/fixtures/dynamic-rest/.marko-run/routes.d.ts
+++ b/packages/run/src/__tests__/fixtures/dynamic-rest/.marko-run/routes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 
 
 declare module "@marko/run" {
@@ -21,6 +21,7 @@ declare module "../src/routes/$$rest/+page.marko" {
     export type Route = Run.Routes["/:rest*"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/__tests__/fixtures/dynamic/.marko-run/routes.d.ts
+++ b/packages/run/src/__tests__/fixtures/dynamic/.marko-run/routes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 
 
 declare module "@marko/run" {
@@ -21,6 +21,7 @@ declare module "../src/routes/$id/+page.marko" {
     export type Route = Run.Routes["/:id"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/__tests__/fixtures/netlify-adapter-page/.marko-run/routes.d.ts
+++ b/packages/run/src/__tests__/fixtures/netlify-adapter-page/.marko-run/routes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 import type { NetlifyEdgePlatformInfo } from '@marko/run-adapter-netlify';
 
 declare module "@marko/run" {
@@ -23,6 +23,7 @@ declare module "../src/routes/+page.marko" {
     export type Route = Run.Routes["/"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/__tests__/fixtures/node-adapter-express-bodyParser/.marko-run/routes.d.ts
+++ b/packages/run/src/__tests__/fixtures/node-adapter-express-bodyParser/.marko-run/routes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 import type { NodePlatformInfo } from '@marko/run-adapter-node'
 
 declare module "@marko/run" {
@@ -23,6 +23,7 @@ declare module "../src/routes/+handler" {
     export type Route = Run.Routes["/"];
     export type Context = Run.MultiRouteContext<Route>;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -33,6 +34,7 @@ declare module "../src/routes/+page.marko" {
     export type Route = Run.Routes["/"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/__tests__/fixtures/node-adapter-express-formData/.marko-run/routes.d.ts
+++ b/packages/run/src/__tests__/fixtures/node-adapter-express-formData/.marko-run/routes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 import type { NodePlatformInfo } from '@marko/run-adapter-node'
 
 declare module "@marko/run" {
@@ -23,6 +23,7 @@ declare module "../src/routes/+handler" {
     export type Route = Run.Routes["/"];
     export type Context = Run.MultiRouteContext<Route>;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -33,6 +34,7 @@ declare module "../src/routes/+page.marko" {
     export type Route = Run.Routes["/"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/__tests__/fixtures/node-adapter-express-import/.marko-run/routes.d.ts
+++ b/packages/run/src/__tests__/fixtures/node-adapter-express-import/.marko-run/routes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 import type { NodePlatformInfo } from '@marko/run-adapter-node'
 
 declare module "@marko/run" {
@@ -23,6 +23,7 @@ declare module "../src/routes/+page.marko" {
     export type Route = Run.Routes["/"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/__tests__/fixtures/node-adapter-express-match/.marko-run/routes.d.ts
+++ b/packages/run/src/__tests__/fixtures/node-adapter-express-match/.marko-run/routes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 import type { NodePlatformInfo } from '@marko/run-adapter-node'
 
 declare module "@marko/run" {
@@ -23,6 +23,7 @@ declare module "../src/routes/+page.marko" {
     export type Route = Run.Routes["/"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/__tests__/fixtures/node-adapter-express/.marko-run/routes.d.ts
+++ b/packages/run/src/__tests__/fixtures/node-adapter-express/.marko-run/routes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 import type { NodePlatformInfo } from '@marko/run-adapter-node'
 
 declare module "@marko/run" {
@@ -23,6 +23,7 @@ declare module "../src/routes/+page.marko" {
     export type Route = Run.Routes["/"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/__tests__/fixtures/node-adapter-page/.marko-run/routes.d.ts
+++ b/packages/run/src/__tests__/fixtures/node-adapter-page/.marko-run/routes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 import type { NodePlatformInfo } from '@marko/run-adapter-node'
 
 declare module "@marko/run" {
@@ -23,6 +23,7 @@ declare module "../src/routes/+page.marko" {
     export type Route = Run.Routes["/"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/__tests__/fixtures/static-adapter-page/.marko-run/routes.d.ts
+++ b/packages/run/src/__tests__/fixtures/static-adapter-page/.marko-run/routes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 
 
 declare module "@marko/run" {
@@ -23,6 +23,7 @@ declare module "../src/routes/+page.marko" {
     export type Route = Run.Routes["/"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/__tests__/fixtures/static-adapter-path-param/.marko-run/routes.d.ts
+++ b/packages/run/src/__tests__/fixtures/static-adapter-path-param/.marko-run/routes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 
 
 declare module "@marko/run" {
@@ -23,6 +23,7 @@ declare module "../src/routes/users.$id+page.marko" {
     export type Route = Run.Routes["/users/:id"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/__tests__/fixtures/static-adapter-rest-param/.marko-run/routes.d.ts
+++ b/packages/run/src/__tests__/fixtures/static-adapter-rest-param/.marko-run/routes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 
 
 declare module "@marko/run" {
@@ -23,6 +23,7 @@ declare module "../src/routes/$$rest+page.marko" {
     export type Route = Run.Routes["/:rest*"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/__tests__/fixtures/uri-encoded/.marko-run/routes.d.ts
+++ b/packages/run/src/__tests__/fixtures/uri-encoded/.marko-run/routes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 
 
 declare module "@marko/run" {
@@ -21,6 +21,7 @@ declare module "../src/routes/a%2fb%2fc/$%24id/+page.marko" {
     export type Route = Run.Routes["/a%2fb%2fc/:$id"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/runtime/index.ts
+++ b/packages/run/src/runtime/index.ts
@@ -15,12 +15,12 @@ import type {
   AnyHandler,
 } from "./types";
 
-
 declare global {
   var __marko_run__: RuntimeModule;
   var __marko_run_vite_config__: InlineConfig | undefined;
-  
+
   namespace MarkoRun {
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: HandlerTypeFn;
     export {
       GetPaths,
@@ -35,7 +35,7 @@ declare global {
       AnyRoute as Route,
       AnyContext as Context,
       AnyHandler as Handler,
-    }
+    };
   }
 }
 

--- a/packages/run/src/vite/__tests__/fixtures/basic/__snapshots__/basic.expected.routetypes.d.ts
+++ b/packages/run/src/vite/__tests__/fixtures/basic/__snapshots__/basic.expected.routetypes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 
 
 declare module "@marko/run" {
@@ -22,6 +22,7 @@ declare module "./+page.marko" {
     export type Route = Run.Routes["/"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -32,6 +33,7 @@ declare module "./fOoBaR/+page.marko" {
     export type Route = Run.Routes["/fOoBaR"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/vite/__tests__/fixtures/build-routes/__snapshots__/build-routes.expected.routetypes.d.ts
+++ b/packages/run/src/vite/__tests__/fixtures/build-routes/__snapshots__/build-routes.expected.routetypes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 
 
 declare module "@marko/run" {
@@ -27,6 +27,7 @@ declare module "./_protected/_home/new/+handler.post" {
     export type Route = Run.Routes["/new"];
     export type Context = Run.MultiRouteContext<Route>;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -37,6 +38,7 @@ declare module "./_protected/_home/notes/$id/+handler.put_post_delete" {
     export type Route = Run.Routes["/notes/:id"];
     export type Context = Run.MultiRouteContext<Route>;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -47,6 +49,7 @@ declare module "./_protected/_home/notes/$id/comments/+handler.put_post_delete" 
     export type Route = Run.Routes["/notes/:id/comments"];
     export type Context = Run.MultiRouteContext<Route>;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -57,6 +60,7 @@ declare module "./callback/oauth2/+handler.get" {
     export type Route = Run.Routes["/callback/oauth2"];
     export type Context = Run.MultiRouteContext<Route>;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -67,6 +71,7 @@ declare module "./my/+handler.get" {
     export type Route = Run.Routes["/my"];
     export type Context = Run.MultiRouteContext<Route>;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -77,6 +82,7 @@ declare module "./$$match/+handler.get" {
     export type Route = Run.Routes["/:match*"];
     export type Context = Run.MultiRouteContext<Route>;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -87,6 +93,7 @@ declare module "./+middleware" {
     export type Route = Run.Routes["/" | "/new" | "/notes/:id" | "/notes/:id/comments" | "/callback/oauth2" | "/my" | "/:match*"];
     export type Context = Run.MultiRouteContext<Route>;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -97,6 +104,7 @@ declare module "./_protected/+middleware" {
     export type Route = Run.Routes["/" | "/new" | "/notes/:id" | "/notes/:id/comments"];
     export type Context = Run.MultiRouteContext<Route>;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -107,6 +115,7 @@ declare module "./_protected/_home/+middleware" {
     export type Route = Run.Routes["/" | "/new" | "/notes/:id" | "/notes/:id/comments"];
     export type Context = Run.MultiRouteContext<Route>;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -117,6 +126,7 @@ declare module "./_protected/_home/notes/$id/+middleware" {
     export type Route = Run.Routes["/notes/:id" | "/notes/:id/comments"];
     export type Context = Run.MultiRouteContext<Route>;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -127,6 +137,7 @@ declare module "./_protected/_home/+page.marko" {
     export type Route = Run.Routes["/"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -137,6 +148,7 @@ declare module "./_protected/_home/new/+page.marko" {
     export type Route = Run.Routes["/new"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -147,6 +159,7 @@ declare module "./_protected/_home/notes/$id/+page.marko" {
     export type Route = Run.Routes["/notes/:id"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -157,6 +170,7 @@ declare module "./my/+page.marko" {
     export type Route = Run.Routes["/my"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -170,6 +184,7 @@ declare module "./+layout.marko" {
     export type Route = Run.Routes["/" | "/new" | "/notes/:id" | "/my"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -183,6 +198,7 @@ declare module "./_protected/_home/+layout.marko" {
     export type Route = Run.Routes["/" | "/new" | "/notes/:id"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -193,6 +209,7 @@ declare module "./+404.marko" {
     export type Route = Run.Route;
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -206,6 +223,7 @@ declare module "./+500.marko" {
     export type Route = globalThis.MarkoRun.Route;
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/vite/__tests__/fixtures/flat-routes/__snapshots__/flat-routes.expected.routetypes.d.ts
+++ b/packages/run/src/vite/__tests__/fixtures/flat-routes/__snapshots__/flat-routes.expected.routetypes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 
 
 declare module "@marko/run" {
@@ -28,6 +28,7 @@ declare module "./foo,(a,b).(c,d)+handler.get.marko" {
     export type Route = Run.Routes["/foo" | "/a/c" | "/a/d" | "/b/c" | "/b/d"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -38,6 +39,7 @@ declare module "./$id,a.d+middleware.marko" {
     export type Route = Run.Routes["/:id" | "/a/d"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -48,6 +50,7 @@ declare module "./foo,$id,$$rest,+page.marko" {
     export type Route = Run.Routes["/" | "/foo" | "/:id" | "/:rest*"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/vite/__tests__/fixtures/multiple-sources/__snapshots__/multiple-sources.expected.routetypes.d.ts
+++ b/packages/run/src/vite/__tests__/fixtures/multiple-sources/__snapshots__/multiple-sources.expected.routetypes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 
 
 declare module "@marko/run" {
@@ -22,6 +22,7 @@ declare module "./+page.marko" {
     export type Route = Run.Routes["/"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -32,6 +33,7 @@ declare module "./+page.marko" {
     export type Route = Run.Routes["/%2Broutes"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/vite/__tests__/fixtures/nested-dynamic/__snapshots__/nested-dynamic.expected.routetypes.d.ts
+++ b/packages/run/src/vite/__tests__/fixtures/nested-dynamic/__snapshots__/nested-dynamic.expected.routetypes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 
 
 declare module "@marko/run" {
@@ -21,6 +21,7 @@ declare module "./foo/$fooId/bar/$bar Id/baz/$1bazId/$qux-Id/+page.marko" {
     export type Route = Run.Routes["/foo/:fooId/bar/:bar Id/baz/:1bazId/:qux-Id"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/vite/__tests__/fixtures/optional-dynamic/__snapshots__/optional-dynamic.expected.routetypes.d.ts
+++ b/packages/run/src/vite/__tests__/fixtures/optional-dynamic/__snapshots__/optional-dynamic.expected.routetypes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 
 
 declare module "@marko/run" {
@@ -24,6 +24,7 @@ declare module "./$foo,/$bar,$$rest/+page.marko" {
     export type Route = Run.Routes["/:foo" | "/:foo/:bar" | "/:foo/:rest*" | "/:rest*"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/vite/__tests__/fixtures/optional-static/__snapshots__/optional-static.expected.routetypes.d.ts
+++ b/packages/run/src/vite/__tests__/fixtures/optional-static/__snapshots__/optional-static.expected.routetypes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 
 
 declare module "@marko/run" {
@@ -28,6 +28,7 @@ declare module "./foo,/bar,/,baz/+page.marko" {
     export type Route = Run.Routes["/" | "/foo" | "/foo/bar" | "/foo/bar/baz" | "/foo/baz" | "/bar" | "/bar/baz" | "/baz"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/vite/__tests__/fixtures/optional-types/__snapshots__/optional-types.expected.routetypes.d.ts
+++ b/packages/run/src/vite/__tests__/fixtures/optional-types/__snapshots__/optional-types.expected.routetypes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 
 
 declare module "@marko/run" {
@@ -24,6 +24,7 @@ declare module "./aaa.$aId.(,bbb.$bId).(,ccc.$cId)/+handler.get" {
     export type Route = Run.Routes["/aaa/:aId" | "/aaa/:aId/bbb/:bId" | "/aaa/:aId/bbb/:bId/ccc/:cId" | "/aaa/:aId/ccc/:cId"];
     export type Context = Run.MultiRouteContext<Route>;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -34,6 +35,7 @@ declare module "./+middleware" {
     export type Route = Run.Routes["/aaa/:aId" | "/aaa/:aId/bbb/:bId" | "/aaa/:aId/bbb/:bId/ccc/:cId" | "/aaa/:aId/ccc/:cId"];
     export type Context = Run.MultiRouteContext<Route>;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -44,6 +46,7 @@ declare module "./aaa.$aId.(,bbb.$bId).(,ccc.$cId)/+page.marko" {
     export type Route = Run.Routes["/aaa/:aId" | "/aaa/:aId/bbb/:bId" | "/aaa/:aId/bbb/:bId/ccc/:cId" | "/aaa/:aId/ccc/:cId"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }
@@ -57,6 +60,7 @@ declare module "./+layout.marko" {
     export type Route = Run.Routes["/aaa/:aId" | "/aaa/:aId/bbb/:bId" | "/aaa/:aId/bbb/:bId/ccc/:cId" | "/aaa/:aId/ccc/:cId"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/vite/__tests__/fixtures/uri-encoded/__snapshots__/uri-encoded.expected.routetypes.d.ts
+++ b/packages/run/src/vite/__tests__/fixtures/uri-encoded/__snapshots__/uri-encoded.expected.routetypes.d.ts
@@ -4,7 +4,7 @@
 */
 
 import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";
-import type Run from "@marko/run";
+import type * as Run from "@marko/run";
 
 
 declare module "@marko/run" {
@@ -21,6 +21,7 @@ declare module "./a%2Fb%2Fc/$%24id/+page.marko" {
     export type Route = Run.Routes["/a%2Fb%2Fc/:$id"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }
 }

--- a/packages/run/src/vite/codegen/index.ts
+++ b/packages/run/src/vite/codegen/index.ts
@@ -33,7 +33,7 @@ export function renderRouteTemplate(route: Route): string {
   }
   return renderEntryTemplate(
     route.entryName,
-    [...route.layouts, route.page].map((file) => `./${file.importPath}`)
+    [...route.layouts, route.page].map((file) => `./${file.importPath}`),
   );
 }
 
@@ -57,7 +57,7 @@ export function renderEntryTemplate(name: string, files: string[]): string {
 function writeEntryTemplateTag(
   writer: Writer,
   [file, ...rest]: string[],
-  index: number = 1
+  index: number = 1,
 ): void {
   if (file) {
     const isLast = !rest.length;
@@ -81,7 +81,7 @@ export function renderRouteEntry(route: Route): string {
 
   if (!verbs) {
     throw new Error(
-      `Route ${key} doesn't have a handler or page for any HTTP verbs`
+      `Route ${key} doesn't have a handler or page for any HTTP verbs`,
     );
   }
 
@@ -109,8 +109,8 @@ export function renderRouteEntry(route: Route): string {
   if (runtimeImports.length) {
     imports.writeLines(
       `import { ${runtimeImports.join(
-        ", "
-      )} } from '${virtualFilePrefix}/runtime/internal';`
+        ", ",
+      )} } from '${virtualFilePrefix}/runtime/internal';`,
     );
   }
 
@@ -118,8 +118,8 @@ export function renderRouteEntry(route: Route): string {
     const names = middleware.map((m) => `mware${m.id}`);
     imports.writeLines(
       `import { ${names.join(
-        ", "
-      )} } from '${virtualFilePrefix}/${markoRunFilePrefix}middleware.js';`
+        ", ",
+      )} } from '${virtualFilePrefix}/${markoRunFilePrefix}middleware.js';`,
     );
   }
 
@@ -133,17 +133,17 @@ export function renderRouteEntry(route: Route): string {
       writer.writeLines(`const ${verb}Handler = normalize(${importName});`);
     }
     imports.writeLines(
-      `import { ${names.join(", ")} } from './${handler.importPath}';`
+      `import { ${names.join(", ")} } from './${handler.importPath}';`,
     );
   }
   if (page) {
     imports.writeLines(
-      `import page from '${virtualFilePrefix}/${entryName}.marko${serverEntryQuery}';`
+      `import page from '${virtualFilePrefix}/${entryName}.marko${serverEntryQuery}';`,
     );
   }
   if (meta) {
     imports.writeLines(
-      `export { default as meta${index} } from './${meta.importPath}';`
+      `export { default as meta${index} } from './${meta.importPath}';`,
     );
   }
 
@@ -158,7 +158,7 @@ function writePageResponse(writer: Writer, wrapFn?: string): void {
   writer.writeLines(
     `${
       wrapFn ? `const ${wrapFn} = () =>` : `return`
-    } pageResponse(page, buildInput());`
+    } pageResponse(page, buildInput());`,
   );
 }
 
@@ -166,11 +166,11 @@ function writeMiddleware(
   writer: Writer,
   middleware: string,
   next: string,
-  wrapFn?: string
+  wrapFn?: string,
 ): void {
   if (wrapFn) {
     writer.writeLines(
-      `const ${wrapFn} = () => call(${middleware}, ${next}, context);`
+      `const ${wrapFn} = () => call(${middleware}, ${next}, context);`,
     );
   } else {
     writer.writeLines(`return call(${middleware}, ${next}, context);`);
@@ -180,7 +180,7 @@ function writeMiddleware(
 function writeRouteEntryHandler(
   writer: Writer,
   route: Route,
-  verb: HttpVerb
+  verb: HttpVerb,
 ): void {
   const { key, index, page, handler, middleware } = route;
   const len = middleware.length;
@@ -193,7 +193,7 @@ function writeRouteEntryHandler(
 
   if (page) {
     writer.writeBlockStart(
-      `export async function ${verb}${index}(context, buildInput) {`
+      `export async function ${verb}${index}(context, buildInput) {`,
     );
   } else {
     writer.writeBlockStart(`export async function ${verb}${index}(context) {`);
@@ -258,7 +258,7 @@ export function renderErrorRouter(
   error: Error,
   options: RouterOptions = {
     trailingSlashes: "RedirectWithout",
-  }
+  },
 ): string {
   const writer = createStringWriter();
 
@@ -306,7 +306,7 @@ export function renderRouter(
   routes: BuiltRoutes,
   options: RouterOptions = {
     trailingSlashes: "RedirectWithout",
-  }
+  },
 ): string {
   const writer = createStringWriter();
 
@@ -315,7 +315,7 @@ export function renderRouter(
   const imports = writer.branch("imports");
 
   imports.writeLines(
-    `import { NotHandled, NotMatched, createContext } from '${virtualFilePrefix}/runtime/internal';`
+    `import { NotHandled, NotMatched, createContext } from '${virtualFilePrefix}/runtime/internal';`,
   );
 
   for (const route of routes.list) {
@@ -326,12 +326,12 @@ export function renderRouter(
     imports.writeLines(
       `import { ${names.join(", ")} } from '${virtualFilePrefix}/${
         route.entryName
-      }.js';`
+      }.js';`,
     );
   }
   for (const { key, entryName } of Object.values(routes.special)) {
     imports.writeLines(
-      `import page${key} from '${virtualFilePrefix}/${entryName}.marko${serverEntryQuery}';`
+      `import page${key} from '${virtualFilePrefix}/${entryName}.marko${serverEntryQuery}';`,
     );
   }
 
@@ -339,7 +339,7 @@ export function renderRouter(
     .writeLines(
       `
 globalThis.__marko_run__ = { match, fetch, invoke };
-    `
+    `,
     )
     .writeBlockStart(`export function match(method, pathname) {`)
     .writeLines(
@@ -347,7 +347,7 @@ globalThis.__marko_run__ = { match, fetch, invoke };
     pathname = '/';
   } else if (pathname.charAt(0) !== '/') {
     pathname = '/' + pathname;
-  }`
+  }`,
     )
     .writeBlockStart(`switch (method) {`);
 
@@ -367,10 +367,10 @@ globalThis.__marko_run__ = { match, fetch, invoke };
   writer
     .writeLines("")
     .writeBlockStart(
-      "export async function invoke(route, request, platform, url) {"
+      "export async function invoke(route, request, platform, url) {",
     )
     .writeLines(
-      "const [context, buildInput] = createContext(route, request, platform, url);"
+      "const [context, buildInput] = createContext(route, request, platform, url);",
     );
 
   const hasErrorPage = Boolean(routes.special[RoutableFileTypes.Error]);
@@ -384,13 +384,13 @@ globalThis.__marko_run__ = { match, fetch, invoke };
     .writeBlockStart("try {")
     .writeLines(
       "const response = await route.handler(context, buildInput);",
-      "if (response) return response;"
+      "if (response) return response;",
     ).indent--;
   writer
     .writeBlockStart("} catch (error) {")
     .writeLines(
       "if (error === NotHandled) return;",
-      "if (error !== NotMatched) throw error;"
+      "if (error !== NotMatched) throw error;",
     )
     .writeBlockEnd("}")
     .writeBlockEnd("}");
@@ -401,7 +401,7 @@ globalThis.__marko_run__ = { match, fetch, invoke };
 const page404ResponseInit = {
   status: 404,
   headers: { "content-type": "text/html;charset=UTF-8" },
-};`
+};`,
     );
 
     writer.write(`    
@@ -423,10 +423,10 @@ const page500ResponseInit = {
     writer
       .writeBlockStart(`} catch (error) {`)
       .writeBlockStart(
-        `if (context.request.headers.get('Accept')?.includes('text/html')) {`
+        `if (context.request.headers.get('Accept')?.includes('text/html')) {`,
       )
       .writeLines(
-        `return new Response(page500.stream(buildInput({ error })), page500ResponseInit);`
+        `return new Response(page500.stream(buildInput({ error })), page500ResponseInit);`,
       )
       .writeBlockEnd("}")
       .writeLines("throw error;")
@@ -496,7 +496,7 @@ function writeRouterVerb(
   trie: RouteTrie,
   verb: HttpVerb,
   level: number = 0,
-  offset: number | string = 1
+  offset: number | string = 1,
 ): void {
   const { route, dynamic, catchAll } = trie;
   let closeCount = 0;
@@ -507,7 +507,7 @@ function writeRouterVerb(
       writer.writeLines(
         `if (len === 1) return ${renderMatch(verb, route, trie.path!)}; // ${
           trie.path!.path
-        }`
+        }`,
       );
     } else if (trie.static || dynamic) {
       writer.writeBlockStart(`if (len > 1) {`);
@@ -543,7 +543,11 @@ function writeRouterVerb(
         const segment = `s${next}`;
         writer.writeLines(`const ${segment} = decodeURIComponent(${value});`);
         value = segment;
-      } else if (terminal?.some(terminal => decodeURIComponent(terminal.key) !== terminal.key)) {
+      } else if (
+        terminal?.some(
+          (terminal) => decodeURIComponent(terminal.key) !== terminal.key,
+        )
+      ) {
         value = `decodeURIComponent(${value})`;
       }
 
@@ -562,7 +566,7 @@ function writeRouterVerb(
             writer.write(`if (${value} === '${decodedKey}') `, true);
           }
           writer.write(
-            `return ${renderMatch(verb, route!, path!)}; // ${path!.path}\n`
+            `return ${renderMatch(verb, route!, path!)}; // ${path!.path}\n`,
           );
         }
 
@@ -576,8 +580,8 @@ function writeRouterVerb(
           `if (${value}) return ${renderMatch(
             verb,
             dynamic.route,
-            dynamic.path!
-          )}; // ${dynamic.path!.path}`
+            dynamic.path!,
+          )}; // ${dynamic.path!.path}`,
         );
       }
     }
@@ -595,7 +599,9 @@ function writeRouterVerb(
         const segment = `s${next}`;
         writer.writeLines(`const ${segment} = decodeURIComponent(${value});`);
         value = segment;
-      } else if (children?.some(child => decodeURIComponent(child.key) !== child.key)) {
+      } else if (
+        children?.some((child) => decodeURIComponent(child.key) !== child.key)
+      ) {
         value = `decodeURIComponent(${value})`;
       }
 
@@ -611,9 +617,7 @@ function writeRouterVerb(
           if (useSwitch) {
             writer.writeBlockStart(`case '${decodedKey}': {`);
           } else {
-            writer.writeBlockStart(
-              `if (${value} === '${decodedKey}') {`
-            );
+            writer.writeBlockStart(`if (${value} === '${decodedKey}') {`);
           }
 
           const nextOffset =
@@ -650,8 +654,8 @@ function writeRouterVerb(
         verb,
         catchAll.route,
         catchAll.path,
-        String(offset)
-      )}; // ${catchAll.path.path}`
+        String(offset),
+      )}; // ${catchAll.path.path}`,
     );
   } else if (level === 0) {
     writer.writeLines("return null;");
@@ -665,7 +669,7 @@ function wrapPropertyName(name: string) {
 
 function renderParams(
   params: Record<string, number | null>,
-  pathIndex?: string
+  pathIndex?: string,
 ): string {
   let result = "";
   let catchAll = "";
@@ -682,7 +686,7 @@ function renderParams(
 
   if (catchAll) {
     result += `${sep} ${wrapPropertyName(
-      catchAll
+      catchAll,
     )}: pathname.slice(${pathIndex})`;
   }
 
@@ -693,7 +697,7 @@ function renderMatch(
   verb: HttpVerb,
   route: Route,
   path: PathInfo,
-  pathIndex?: string
+  pathIndex?: string,
 ) {
   const handler = `${verb}${route.index}`;
   const params = path.params ? renderParams(path.params, pathIndex) : "{}";
@@ -705,12 +709,12 @@ function renderMatch(
 export function renderMiddleware(middleware: RoutableFile[]): string {
   const writer = createStringWriter();
   writer.writeLines(
-    `// ${virtualFilePrefix}/${markoRunFilePrefix}middleware.js`
+    `// ${virtualFilePrefix}/${markoRunFilePrefix}middleware.js`,
   );
 
   const imports = writer.branch("imports");
   imports.writeLines(
-    `import { normalize } from '${virtualFilePrefix}/runtime/internal';`
+    `import { normalize } from '${virtualFilePrefix}/runtime/internal';`,
   );
 
   writer.writeLines("");
@@ -739,7 +743,7 @@ function stripTsExtension(path: string) {
 export async function renderRouteTypeInfo(
   routes: BuiltRoutes,
   pathPrefix: string = ".",
-  adapter?: Adapter | null
+  adapter?: Adapter | null,
 ) {
   const writer = createStringWriter();
   writer.writeLines(
@@ -749,7 +753,7 @@ export async function renderRouteTypeInfo(
 */
 `,
     `import { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform } from "@marko/run/namespace";`,
-    `import type Run from "@marko/run";`
+    `import type * as Run from "@marko/run";`,
   );
 
   const headWriter = writer.branch("head");
@@ -758,7 +762,7 @@ export async function renderRouteTypeInfo(
 
   if (adapter && adapter.typeInfo) {
     const platformType = await adapter.typeInfo((data) =>
-      headWriter.write(data)
+      headWriter.write(data),
     );
     if (platformType) {
       writer.writeLines(`interface Platform extends ${platformType} {}\n`);
@@ -844,7 +848,7 @@ export async function renderRouteTypeInfo(
           `
   export interface Input {
     renderBody: Marko.Body;
-  }`
+  }`,
         );
         break;
       case RoutableFileTypes.Error:
@@ -855,7 +859,7 @@ export async function renderRouteTypeInfo(
           `
   export interface Input {
     error: unknown;
-  }`
+  }`,
         );
         break;
       case RoutableFileTypes.NotFound:
@@ -907,7 +911,7 @@ function writeModuleDeclaration(
   writer: Writer,
   path: string,
   routeType?: string,
-  moduleTypes?: string
+  moduleTypes?: string,
 ) {
   writer.writeLines("").write(`declare module "${stripTsExtension(path)}" {`);
 
@@ -925,6 +929,7 @@ function writeModuleDeclaration(
       isMarko ? " & Marko.Global" : ""
     };
     export type Handler = Run.HandlerLike<Route>;
+    /** @deprecated use \`((context, next) => { ... }) satisfies MarkoRun.Handler\` instead */
     export const route: Run.HandlerTypeFn<Route>;
   }`);
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Deprecate `MarkoRun.route`

> [!Note]
> **Bonus Change**: prettier

## Motivation and Context

We should use this instead:
```ts
export const GET = (async (context, next) => {
  ...
}) satisfies MarkoRun.Handler;
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->