### PR TITLE
fix: node-adapter origin host/protocol determination

### DIFF
--- a/packages/run/src/__tests__/fixtures/node-adapter-page/__snapshots__/dev.expected.loading.0.html
+++ b/packages/run/src/__tests__/fixtures/node-adapter-page/__snapshots__/dev.expected.loading.0.html
@@ -1,1 +1,1 @@
-Page rendered
+https://markojs.com/

--- a/packages/run/src/__tests__/fixtures/node-adapter-page/__snapshots__/preview.expected.loading.0.html
+++ b/packages/run/src/__tests__/fixtures/node-adapter-page/__snapshots__/preview.expected.loading.0.html
@@ -1,1 +1,1 @@
-Page rendered
+https://markojs.com/

--- a/packages/run/src/__tests__/fixtures/node-adapter-page/src/routes/+page.marko
+++ b/packages/run/src/__tests__/fixtures/node-adapter-page/src/routes/+page.marko
@@ -5,6 +5,6 @@
     <title>@marko/run Test Fixture</title>
   </head>
   <body>
-    <div#app>Page rendered</div>
+    <div#app>${$global.url}</div>
   </body>
 </html>

--- a/packages/run/src/__tests__/main.test.cts
+++ b/packages/run/src/__tests__/main.test.cts
@@ -44,8 +44,15 @@ let context: playwright.BrowserContext;
 let changes: string[] = [];
 
 before(async () => {
+  process.env.TRUST_PROXY = "1";
+
   browser = await playwright.chromium.launch();
-  context = await browser.newContext();
+  context = await browser.newContext({
+    extraHTTPHeaders: {
+      'x-forwarded-proto': 'https',
+      'x-forwarded-host': 'markojs.com',
+    }
+  });
 
   /**
    * We add a mutation observer to track all mutations (batched)

--- a/packages/run/src/adapter/middleware.ts
+++ b/packages/run/src/adapter/middleware.ts
@@ -55,12 +55,12 @@ function getForwardedHeader(req: IncomingMessage, name: string) {
 
 export function getOrigin(req: IncomingMessage, trustProxy?: boolean): string {
   const protocol =
-    (req as any).protocol ||
     (trustProxy && getForwardedHeader(req, "proto")) ||
-    ((req.socket as TLSSocket).encrypted ? "https" : "http");
+    ((req.socket as TLSSocket).encrypted && "https") ||
+    (req as any).protocol || "http";
 
   let host =
-    req.headers.host || (trustProxy && getForwardedHeader(req, "host"));
+    (trustProxy && getForwardedHeader(req, "host")) || req.headers.host;
 
   if (!host) {
     if (process.env.NODE_ENV !== "production") {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Node Adapter: changes the way host and protocol are determined by preferring the `X-Forwarded-` headers

<!--- Describe your changes in detail.  Include the package name if applicable. -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->