### PR TITLE
fix: ensure modules dir is under root

### DIFF
--- a/packages/run/src/vite/plugin.ts
+++ b/packages/run/src/vite/plugin.ts
@@ -328,7 +328,7 @@ export default function markoRun(opts: Options = {}): Plugin[] {
         markoVitePluginOptions.basePathVar = opts.basePathVar;
         resolvedRoutesDir = path.resolve(root, routesDir);
 
-        const modulesDir = getModulesDir() || path.join(root, "node_modules");
+        const modulesDir = getModulesDir(root);
         entryFilesDir = path.join(
           modulesDir,
           ".marko",
@@ -775,9 +775,12 @@ function getImporters(
   return seen;
 }
 
-function getModulesDir(dir: string = __dirname) {
-  const index = dir.indexOf("node_modules");
-  if (index >= 0) {
-    return dir.slice(0, index + 12);
+function getModulesDir(root: string, dir: string = __dirname) {
+  if (dir.startsWith(root)) {
+    const index = dir.indexOf("node_modules");
+    if (index >= 0) {
+      return dir.slice(0, index + 12);
+    }
   }
+  return path.join(root, "node_modules");
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This change ensures the directory used for outputting generated marko files is under the root. Previously if the directory used was outside of the project root, Rollup will error during build and Vite will error in dev mode.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->