### PR TITLE
Fix port

### DIFF
--- a/packages/run/src/adapter/load-dev-worker.mjs
+++ b/packages/run/src/adapter/load-dev-worker.mjs
@@ -1,3 +1,4 @@
+import net from "net";
 import { createServer } from "vite";
 import { getDevGlobal } from "@marko/run/adapter";
 
@@ -26,7 +27,9 @@ async function start(entry, config) {
     ssr: { external: ["@marko/run/router"] },
   });
 
-  await loader.listen(0);
+  const port = await getAvailablePort();
+  await loader.listen(port);
+  
   loader.ssrLoadModule(entry).catch((err) => {
     loader.ssrFixStacktrace(err);
 
@@ -58,4 +61,13 @@ function shutdown() {
     devServer.ws.send({ type: "full-reload" });
   }
   devGlobal.clear();
+}
+
+async function getAvailablePort() {
+  return new Promise((resolve) => {
+    const server = net.createServer().listen(0, () => {
+      const { port } = server.address();
+      server.close(() => resolve(port));
+    });
+  });
 }

--- a/packages/run/src/cli/commands.ts
+++ b/packages/run/src/cli/commands.ts
@@ -19,11 +19,12 @@ import {
   default as plugin,
   resolveAdapter as pluginResolveAdapter,
   isPluginIncluded,
+  defaultPort,
+  
 } from "../vite/plugin";
 import type { StartDevOptions, StartPreviewOptions } from "../vite/types";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const defaultPort = Number(process.env.PORT || 3000);
 
 export const defaultConfigFileBases = ["serve.config", "vite.config"];
 export const defaultConfigFileExts = [".js", ".cjs", ".mjs", ".ts", ".mts"];

--- a/packages/run/src/vite/plugin.ts
+++ b/packages/run/src/vite/plugin.ts
@@ -62,6 +62,8 @@ const CLIENT_OUT_DIR = "public";
 const MIDDLEWARE_FILENAME = `${markoRunFilePrefix}middleware.js`;
 const ROUTER_FILENAME = `${markoRunFilePrefix}router.js`;
 
+export const defaultPort = Number(process.env.PORT || 3000);
+
 const normalizePath =
   path.sep === WINDOWS_SEP
     ? (id: string) => id.replace(/\\/g, POSIX_SEP)
@@ -452,6 +454,9 @@ export default function markoRun(opts: Options = {}): Plugin[] {
                 ],
               }
             : undefined,
+          server: !isBuild ? {
+            port: config.server?.port || defaultPort
+          } : undefined
         };
 
         if (adapter?.viteConfig) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Restores port 3000 as the default port
- Ensure the dev server which loads custom entry files uses an unused port

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->