### PR TITLE
fix: [node] body disturbed when creating request

### DIFF
--- a/packages/run/src/__tests__/fixtures/node-adapter-express-bodyParser/test.config.ts
+++ b/packages/run/src/__tests__/fixtures/node-adapter-express-bodyParser/test.config.ts
@@ -14,9 +14,7 @@ async function submitPost() {
   }, {} as Record<string, string>);
 
   const response = await page.request.post(page.url(), { form });
-
-  const html = await response.text();
-
+  
   assert.equal(response.ok(), false);
-  assert.match(await response.text(), /The request body stream was already consumed by something before Marko Run/);
+  assert.match(await response.text(), /The request body stream has been destroyed or consumed by something before Marko Run/);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes intermittent issue in base (node) adapter that throws a type error: `Response body object should not be disturbed or locked`

## Motivation and Context

When the socket is closed, the request stream will be considered "disturbed" and will throw when creating a WHATWG request.

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->