### PR TITLE
Optional dynamic nested

### DIFF
--- a/.changeset/wet-tools-wash.md
+++ b/.changeset/wet-tools-wash.md
@@ -1,0 +1,5 @@
+---
+"@marko/run": patch
+---
+
+Fix chained optional dynamic params

--- a/packages/run/src/runtime/types.ts
+++ b/packages/run/src/runtime/types.ts
@@ -1,14 +1,7 @@
 export type Awaitable<T> = Promise<T> | T;
 type OneOrMany<T> = T | T[];
 type NoParams = {};
-type AllKeys<T> = T extends T ? keyof T : never;
 type Simplify<T> = T extends unknown ? { [K in keyof T]: T[K] } : never;
-type SuperSet<T, U extends T> = Simplify<
-  T & { [K in AllKeys<U> as K extends keyof T ? never : K]: undefined }
->;
-type SuperSets<T, U extends T, K extends keyof T> = Omit<T, K> & {
-  [P in K]: SuperSet<T[P], U[P]>;
-};
 
 export interface Platform {}
 
@@ -22,11 +15,8 @@ export interface Context<TRoute extends Route = AnyRoute> {
   readonly serializedGlobals: Record<string, boolean>;
 }
 
-export type MultiRouteContext<
-  TRoute extends Route,
-  _Preserved extends TRoute = TRoute,
-> = TRoute extends any
-  ? Context<Simplify<SuperSets<TRoute, _Preserved, "params">>>
+export type MultiRouteContext<TRoute extends Route> = TRoute extends any
+  ? Context<Simplify<TRoute>>
   : never;
 export type ParamsObject = Record<string, string>;
 export type InputObject = Record<PropertyKey, any>;

--- a/packages/run/src/vite/__tests__/fixtures/error-invalid-routes/__snapshots__/error-invalid-routes.expected.router.js
+++ b/packages/run/src/vite/__tests__/fixtures/error-invalid-routes/__snapshots__/error-invalid-routes.expected.router.js
@@ -1,1 +1,1 @@
-throw {"message":"Duplicate file type 'page' added at path '/$'. File 'src/routes/$bar+page.marko' collides with 'src/routes/$foo+page.marko'.","stack":"    at [Normalized Error Stack]","frame":""}
+throw {"message":"Duplicate routes for path '/$' were defined. A route established by:\n      /$foo+page.marko via '/$foo'\n        collides with\n      /$bar+page.marko via '/$bar'\n      ","stack":"      at [Normalized Error Stack]","frame":""}

--- a/packages/run/src/vite/__tests__/fixtures/optional-dynamic/__snapshots__/optional-dynamic.expected.router.js
+++ b/packages/run/src/vite/__tests__/fixtures/optional-dynamic/__snapshots__/optional-dynamic.expected.router.js
@@ -1,8 +1,8 @@
 // @marko/run/router
 import { NotHandled, NotMatched, createContext } from 'virtual:marko-run/runtime/internal';
-import { get1, head1 } from 'virtual:marko-run/__marko-run__route.$foo.js';
-import { get2, head2 } from 'virtual:marko-run/__marko-run__route.$foo.$bar.js';
-import { get3, head3 } from 'virtual:marko-run/__marko-run__route.$foo.$$rest.js';
+import { get1, head1 } from 'virtual:marko-run/__marko-run__route.$foo.$bar.js';
+import { get2, head2 } from 'virtual:marko-run/__marko-run__route.$foo.$$rest.js';
+import { get3, head3 } from 'virtual:marko-run/__marko-run__route.$bar.js';
 import { get4, head4 } from 'virtual:marko-run/__marko-run__route.$$rest.js';
 
 globalThis.__marko_run__ = { match, fetch, invoke };
@@ -21,16 +21,16 @@ export function match(method, pathname) {
 				const i1 = pathname.indexOf('/', 1) + 1;
 				if (!i1 || i1 === len) {
 					const s1 = decodeURIComponent(pathname.slice(1, i1 ? -1 : len));
-					if (s1) return { handler: get1, params: { foo: s1 }, meta: {}, path: '/:foo' }; // /$foo
+					if (s1) return { handler: get3, params: { bar: s1 }, meta: {}, path: '/:bar' }; // /$bar
 				} else {
 					const s1 = decodeURIComponent(pathname.slice(1, i1 - 1));
 					if (s1) {
 						const i2 = pathname.indexOf('/', i1) + 1;
 						if (!i2 || i2 === len) {
 							const s2 = decodeURIComponent(pathname.slice(i1, i2 ? -1 : len));
-							if (s2) return { handler: get2, params: { foo: s1, bar: s2 }, meta: {}, path: '/:foo/:bar' }; // /$foo/$bar
+							if (s2) return { handler: get1, params: { foo: s1, bar: s2 }, meta: {}, path: '/:foo/:bar' }; // /$foo/$bar
 						}
-						return { handler: get3, params: { foo: s1, rest: pathname.slice(i1) }, meta: {}, path: '/:foo/:rest*' }; // /$foo/$$rest
+						return { handler: get2, params: { foo: s1, rest: pathname.slice(i1) }, meta: {}, path: '/:foo/:rest*' }; // /$foo/$$rest
 					}
 				}
 			}
@@ -43,16 +43,16 @@ export function match(method, pathname) {
 				const i1 = pathname.indexOf('/', 1) + 1;
 				if (!i1 || i1 === len) {
 					const s1 = decodeURIComponent(pathname.slice(1, i1 ? -1 : len));
-					if (s1) return { handler: head1, params: { foo: s1 }, meta: {}, path: '/:foo' }; // /$foo
+					if (s1) return { handler: head3, params: { bar: s1 }, meta: {}, path: '/:bar' }; // /$bar
 				} else {
 					const s1 = decodeURIComponent(pathname.slice(1, i1 - 1));
 					if (s1) {
 						const i2 = pathname.indexOf('/', i1) + 1;
 						if (!i2 || i2 === len) {
 							const s2 = decodeURIComponent(pathname.slice(i1, i2 ? -1 : len));
-							if (s2) return { handler: head2, params: { foo: s1, bar: s2 }, meta: {}, path: '/:foo/:bar' }; // /$foo/$bar
+							if (s2) return { handler: head1, params: { foo: s1, bar: s2 }, meta: {}, path: '/:foo/:bar' }; // /$foo/$bar
 						}
-						return { handler: head3, params: { foo: s1, rest: pathname.slice(i1) }, meta: {}, path: '/:foo/:rest*' }; // /$foo/$$rest
+						return { handler: head2, params: { foo: s1, rest: pathname.slice(i1) }, meta: {}, path: '/:foo/:rest*' }; // /$foo/$$rest
 					}
 				}
 			}

--- a/packages/run/src/vite/__tests__/fixtures/optional-dynamic/__snapshots__/optional-dynamic.expected.routes.md
+++ b/packages/run/src/vite/__tests__/fixtures/optional-dynamic/__snapshots__/optional-dynamic.expected.routes.md
@@ -1,11 +1,11 @@
 # Routes
 
-## Route `/$foo`
+## Route `/$foo/$bar`
 ### Paths
-  - `/$foo`
+  - `/$foo/$bar`
 ### Handler
 ```js
-// virtual:marko-run/__marko-run__route.$foo.js
+// virtual:marko-run/__marko-run__route.$foo.$bar.js
 import { pageResponse, stripResponseBody } from 'virtual:marko-run/runtime/internal';
 import page from './src/routes/$foo,/$bar,$$rest/+page.marko?marko-server-entry';
 
@@ -18,12 +18,12 @@ export function head1(context, buildInput) {
 }
 ```
 ---
-## Route `/$foo/$bar`
+## Route `/$foo/$$rest`
 ### Paths
-  - `/$foo/$bar`
+  - `/$foo/$$rest`
 ### Handler
 ```js
-// virtual:marko-run/__marko-run__route.$foo.$bar.js
+// virtual:marko-run/__marko-run__route.$foo.$$rest.js
 import { pageResponse, stripResponseBody } from 'virtual:marko-run/runtime/internal';
 import page from './src/routes/$foo,/$bar,$$rest/+page.marko?marko-server-entry';
 
@@ -36,12 +36,12 @@ export function head2(context, buildInput) {
 }
 ```
 ---
-## Route `/$foo/$$rest`
+## Route `/$bar`
 ### Paths
-  - `/$foo/$$rest`
+  - `/$bar`
 ### Handler
 ```js
-// virtual:marko-run/__marko-run__route.$foo.$$rest.js
+// virtual:marko-run/__marko-run__route.$bar.js
 import { pageResponse, stripResponseBody } from 'virtual:marko-run/runtime/internal';
 import page from './src/routes/$foo,/$bar,$$rest/+page.marko?marko-server-entry';
 

--- a/packages/run/src/vite/__tests__/fixtures/optional-dynamic/__snapshots__/optional-dynamic.expected.routetypes.d.ts
+++ b/packages/run/src/vite/__tests__/fixtures/optional-dynamic/__snapshots__/optional-dynamic.expected.routetypes.d.ts
@@ -10,9 +10,9 @@ import type * as Run from "@marko/run";
 declare module "@marko/run" {
 	interface AppData extends Run.DefineApp<{
 		routes: {
-			"/:foo": Routes["/$foo"];
 			"/:foo/:bar": Routes["/$foo/$bar"];
 			"/:foo/:rest*": Routes["/$foo/$$rest"];
+			"/:bar": Routes["/$bar"];
 			"/:rest*": Routes["/$$rest"];
 		}
 	}> {}
@@ -21,7 +21,7 @@ declare module "@marko/run" {
 declare module "./$foo,/$bar,$$rest/+page.marko" {
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
-    export type Route = Run.Routes["/:foo" | "/:foo/:bar" | "/:foo/:rest*" | "/:rest*"];
+    export type Route = Run.Routes["/:foo/:bar" | "/:foo/:rest*" | "/:bar" | "/:rest*"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
     /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
@@ -30,8 +30,8 @@ declare module "./$foo,/$bar,$$rest/+page.marko" {
 }
 
 type Routes = {
-	"/$foo": { verb: "get"; };
 	"/$foo/$bar": { verb: "get"; };
 	"/$foo/$$rest": { verb: "get"; };
+	"/$bar": { verb: "get"; };
 	"/$$rest": { verb: "get"; };
 }

--- a/packages/run/src/vite/__tests__/parse-flat-route.test.ts
+++ b/packages/run/src/vite/__tests__/parse-flat-route.test.ts
@@ -93,6 +93,14 @@ describe("parse-flat-route", () => {
     );
   });
 
+  it("should work for optional nested dynamic segments", () => {
+    const actual = parseFlatRoute("($a,).$b");
+    assert.deepEqual(
+      actual.map((path) => path.segments.map((s) => s.raw).join("/")),
+      ["$a/$b", "$b"],
+    );
+  });
+
   it("should thow for ambiguous hoisting", () => {
     assert.throws(
       () => parseFlatRoute("(a,).(,a)"),

--- a/packages/run/src/vite/__tests__/route-builder.test.ts
+++ b/packages/run/src/vite/__tests__/route-builder.test.ts
@@ -132,6 +132,17 @@ describe("route-builder", () => {
     );
   });
 
+  it("should work for optional dynamic segements", async () => {
+    await fixture(
+      `
+        /$foo,
+          /$bar
+            +page.marko
+      `,
+      { path: "/$foo/$bar", params: { foo: 0, bar: 1 } },
+      { path: "/$bar", params: { bar: 0 } },
+    );
+  });
   it("should throw on ambiguous hoisting", async () => {
     await assert.rejects(
       () =>

--- a/packages/run/src/vite/routes/builder.ts
+++ b/packages/run/src/vite/routes/builder.ts
@@ -189,11 +189,11 @@ export async function buildRoutes(
             .filter(Boolean)
             .map((f) => f!.filePath);
           throw new Error(`Duplicate routes for path '${
-            path.path
+            path.id
           }' were defined. A route established by:
-      ${existingFiles.join(" and ")} via '${existing.dir.path}'
+      ${existingFiles.join(" and ")} via '${existing.dir.fullPath}'
         collides with
-      ${currentFiles.join(" and ")} via '${dir.path}'
+      ${currentFiles.join(" and ")} via '${dir.fullPath}'
       `);
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes issue where nested optional dynamic segments always used the first parameter
Fixes `Context` params type which made route specific `Context`s incompatible with `AnyContext`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
