### PR TITLE
fix: ensure multi-route context params are supersets

### DIFF
--- a/.changeset/lucky-geese-remain.md
+++ b/.changeset/lucky-geese-remain.md
@@ -1,0 +1,5 @@
+---
+"@marko/run": patch
+---
+
+Ensure multi-route context params are supersets

--- a/packages/run/src/runtime/types.ts
+++ b/packages/run/src/runtime/types.ts
@@ -1,7 +1,14 @@
 export type Awaitable<T> = Promise<T> | T;
 type OneOrMany<T> = T | T[];
 type NoParams = {};
+type AllKeys<T> = T extends T ? keyof T : never;
 type Simplify<T> = T extends unknown ? { [K in keyof T]: T[K] } : never;
+type SuperSet<T, U extends T> = T & {
+  [K in AllKeys<U> as K extends keyof T ? never : K]?: never;
+};
+type SuperSets<T, U extends T, K extends keyof T> = Omit<T, K> & {
+  [P in K]: Simplify<SuperSet<T[P], U[P]>>;
+};
 
 export interface Platform {}
 
@@ -15,9 +22,13 @@ export interface Context<TRoute extends Route = AnyRoute> {
   readonly serializedGlobals: Record<string, boolean>;
 }
 
-export type MultiRouteContext<TRoute extends Route> = TRoute extends any
-  ? Context<Simplify<TRoute>>
+export type MultiRouteContext<
+  TRoute extends Route,
+  _Preserved extends TRoute = TRoute,
+> = TRoute extends any
+  ? Context<Simplify<SuperSets<TRoute, _Preserved, "params">>>
   : never;
+
 export type ParamsObject = Record<string, string>;
 export type InputObject = Record<PropertyKey, any>;
 export type NextFunction = () => Awaitable<Response>;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changes multi-route context params to each be a superset of all params in the union of routes. This reverts [this change](https://github.com/marko-js/run/pull/113/commits/8222cfeebf6d0a3e6997390246bfca700c571f8f) but fixes the issue of specific multi-route contexts not being assignable to `AnyContext`/`MarkoRun.Context` outside of a routed file.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
