### PR TITLE
fix(netlify): add support for deno readable stream on Response for Marko 6

### DIFF
--- a/.changeset/hungry-yaks-exist.md
+++ b/.changeset/hungry-yaks-exist.md
@@ -1,0 +1,5 @@
+---
+"@marko/run": patch
+---
+
+fix(netlify): add support for deno readable stream on Response for Marko 6

--- a/packages/run/src/runtime/internal.ts
+++ b/packages/run/src/runtime/internal.ts
@@ -18,7 +18,13 @@ export function pageResponse(
   template: any,
   input: Record<PropertyKey, unknown>,
 ): Response {
-  return new Response(template.render(input), pageResponseInit);
+  const renderResult = template.render(input);
+  return new Response(
+    typeof renderResult.toReadable === "function"
+      ? renderResult.toReadable()
+      : renderResult,
+    pageResponseInit,
+  );
 }
 
 export const NotHandled: typeof MarkoRun.NotHandled = Symbol() as any;


### PR DESCRIPTION
## Description

- Use new `toReadable()` server render result when available to force a ReadableStream

## Motivation and Context

Marko 6 supports `toReadable()` in the [ServerRendered](https://github.com/marko-js/marko/blob/main/packages/runtime-tags/src/html/template.ts#L159) template result. Deno on Netlify doesn't automatically consider the asyncInterator as a stream when passed to the Response object, it instead uses the `toString()` causing an error during `await` usage.

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
