### PR TITLE
Replace `stream` with `render` for 404 and 500 pages

### DIFF
--- a/.changeset/gorgeous-goats-switch.md
+++ b/.changeset/gorgeous-goats-switch.md
@@ -1,0 +1,5 @@
+---
+"@marko/run": patch
+---
+
+Replace stream with render for 404 and 500 pages

--- a/packages/run/src/runtime/internal.ts
+++ b/packages/run/src/runtime/internal.ts
@@ -54,11 +54,9 @@ let toReadable = (rendered: Rendered): ReadableStream<Uint8Array> => {
 export function pageResponse(
   template: Marko.Template,
   input: Record<PropertyKey, unknown>,
+  init: ResponseInit = pageResponseInit,
 ) {
-  return new Response(
-    toReadable(template.render(input) as Rendered),
-    pageResponseInit,
-  );
+  return new Response(toReadable(template.render(input) as Rendered), init);
 }
 
 export function createContext<TRoute extends AnyRoute>(

--- a/packages/run/src/vite/__tests__/fixtures/basic-500/__snapshots__/basic-500.expected.router.js
+++ b/packages/run/src/vite/__tests__/fixtures/basic-500/__snapshots__/basic-500.expected.router.js
@@ -1,5 +1,5 @@
 // @marko/run/router
-import { NotHandled, NotMatched, createContext } from 'virtual:marko-run/runtime/internal';
+import { NotHandled, NotMatched, createContext, pageResponse } from 'virtual:marko-run/runtime/internal';
 import { get1, head1 } from 'virtual:marko-run/__marko-run__route.js';
 import page500 from './.marko/route.500.marko?marko-server-entry';
 
@@ -47,7 +47,7 @@ export async function invoke(route, request, platform, url) {
 		}
 	} catch (error) {
 		if (context.request.headers.get('Accept')?.includes('text/html')) {
-			return new Response(page500.stream(buildInput({ error })), page500ResponseInit);
+			return pageResponse(page500, buildInput({ error }), page500ResponseInit);
 		}
 		throw error;
 	}

--- a/packages/run/src/vite/__tests__/fixtures/build-routes/__snapshots__/build-routes.expected.router.js
+++ b/packages/run/src/vite/__tests__/fixtures/build-routes/__snapshots__/build-routes.expected.router.js
@@ -1,5 +1,5 @@
 // @marko/run/router
-import { NotHandled, NotMatched, createContext } from 'virtual:marko-run/runtime/internal';
+import { NotHandled, NotMatched, createContext, pageResponse } from 'virtual:marko-run/runtime/internal';
 import { get1, head1 } from 'virtual:marko-run/__marko-run__route._protected._home.js';
 import { get2, head2, post2, meta2 } from 'virtual:marko-run/__marko-run__route._protected._home.new.js';
 import { get3, head3, post3, put3, delete3 } from 'virtual:marko-run/__marko-run__route._protected._home.notes.$id.js';
@@ -182,11 +182,11 @@ export async function invoke(route, request, platform, url) {
 		}
     
     if (context.request.headers.get('Accept')?.includes('text/html')) {
-      return new Response(page404.stream(buildInput()), page404ResponseInit);
+      return pageResponse(page404, buildInput(), page404ResponseInit);
     }
 	} catch (error) {
 		if (context.request.headers.get('Accept')?.includes('text/html')) {
-			return new Response(page500.stream(buildInput({ error })), page500ResponseInit);
+			return pageResponse(page500, buildInput({ error }), page500ResponseInit);
 		}
 		throw error;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Updates 404 and 500 page responses to use the same `pageResponse` helper all other page responses use
- Fixes `toRenderable` polyfill to prevent external cancellation from throwing

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
