### PR TITLE
fix(adapter-static): updated marko/vite and updated reference to htmlparser2

### DIFF
--- a/.changeset/public-waves-worry.md
+++ b/.changeset/public-waves-worry.md
@@ -1,0 +1,6 @@
+---
+"@marko/run-adapter-static": patch
+"@marko/run": patch
+---
+
+fix(adapter-static): updated marko/vite and updated reference to htmlparser2

--- a/.changeset/public-waves-worry.md
+++ b/.changeset/public-waves-worry.md
@@ -3,4 +3,4 @@
 "@marko/run": patch
 ---
 
-fix(adapter-static): updated marko/vite and updated reference to htmlparser2
+fix(adapter-static): updated marko/vite and add missing dependency on htmlparser2

--- a/package-lock.json
+++ b/package-lock.json
@@ -6648,7 +6648,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
       "integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -8181,9 +8180,9 @@
       "license": "MIT"
     },
     "node_modules/htmlparser2": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
-      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -8195,20 +8194,8 @@
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.1.0",
-        "entities": "^4.5.0"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
       }
     },
     "node_modules/http-cache-semantics": {
@@ -30338,7 +30325,7 @@
       "license": "MIT",
       "dependencies": {
         "@marko/run-explorer": "^2.0.0",
-        "@marko/vite": "^5.1.1",
+        "@marko/vite": "^5.1.7",
         "browserslist": "^4.24.4",
         "cli-table3": "^0.6.5",
         "compression": "^1.8.0",
@@ -30394,23 +30381,23 @@
       }
     },
     "packages/run/node_modules/@marko/vite": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@marko/vite/-/vite-5.1.5.tgz",
-      "integrity": "sha512-NnDSwq7EGnvU7xyvVhJ9T7+42aSNwhFiL3F/iMvwlakqz3OYbDKOsacRfNmamqKgixiG/j563ZrcNdF3/X2mdw==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/@marko/vite/-/vite-5.1.7.tgz",
+      "integrity": "sha512-XfRzsGPdDTNmuVsJoHiswxGQlWsLwM2xk/+OORPVsX25JmYryjxmDsXgJZ4sZ4yNOr8dmzQyAsu43twbiKma+g==",
       "license": "MIT",
       "dependencies": {
         "@chialab/cjs-to-esm": "^0.18.0",
         "anymatch": "^3.1.3",
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
-        "fast-glob": "^3.3.2",
-        "htmlparser2": "^9.1.0",
-        "resolve": "^1.22.8",
-        "resolve.exports": "^2.0.2"
+        "fast-glob": "^3.3.3",
+        "htmlparser2": "^10.0.0",
+        "resolve": "^1.22.10",
+        "resolve.exports": "^2.0.3"
       },
       "peerDependencies": {
         "@marko/compiler": "^5",
-        "vite": "4 - 6"
+        "vite": "4 - 7"
       }
     },
     "packages/run/node_modules/@types/node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3663,6 +3663,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/domhandler": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@types/domhandler/-/domhandler-2.4.5.tgz",
+      "integrity": "sha512-lANhC2grmFG1gBac/8sDAKdIXx+TzAdkJIAjEOSMA+qW3297ybACEbacJnG15aNYfrzDO6fdcoouokqAKsy6aQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/domutils": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@types/domutils/-/domutils-1.7.8.tgz",
+      "integrity": "sha512-iZGboDV79ibrO3D625p9yD+VgmMDnyJocdIRJvu9Xz66R8SHfOY/XNgdjY5SFoFiLgILceVfSLt7IUhlk1Vhhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/domhandler": "^2.4.0"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
@@ -3703,6 +3720,36 @@
       "dependencies": {
         "@types/minimatch": "^5.1.2",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/htmlparser2": {
+      "version": "3.10.7",
+      "resolved": "https://registry.npmjs.org/@types/htmlparser2/-/htmlparser2-3.10.7.tgz",
+      "integrity": "sha512-ycBs4PNr9rY9XFFp4WkP+M1UcO49ahn0+9b24cmIY6KWy0w35rW0G8+JTTe9Rp6Wnyqn5SEHZrhCBMa0TIOxBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/domhandler": "^2.4.3",
+        "@types/domutils": "*",
+        "@types/node": "*",
+        "domhandler": "^2.4.0"
+      }
+    },
+    "node_modules/@types/htmlparser2/node_modules/domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@types/htmlparser2/node_modules/domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "1"
       }
     },
     "node_modules/@types/http-errors": {
@@ -30108,10 +30155,12 @@
       "license": "MIT",
       "dependencies": {
         "compression": "^1.8.0",
+        "htmlparser2": "^10.0.0",
         "sirv": "^1.0.15",
         "undici": "^6.21.0"
       },
       "devDependencies": {
+        "@types/htmlparser2": "^3.10.7",
         "@types/mocha": "^10.0.10",
         "@types/node": "^22.9.1",
         "@types/serve-static": "^1.15.7",

--- a/packages/adapters/static/package.json
+++ b/packages/adapters/static/package.json
@@ -26,10 +26,12 @@
   },
   "dependencies": {
     "compression": "^1.8.0",
+    "htmlparser2": "^10.0.0",
     "sirv": "^1.0.15",
     "undici": "^6.21.0"
   },
   "devDependencies": {
+    "@types/htmlparser2": "^3.10.7",
     "@types/mocha": "^10.0.10",
     "@types/node": "^22.9.1",
     "@types/serve-static": "^1.15.7",

--- a/packages/adapters/static/src/crawler.ts
+++ b/packages/adapters/static/src/crawler.ts
@@ -1,5 +1,5 @@
 import fs from "fs";
-import { WritableStream as Parser } from "htmlparser2/lib/WritableStream";
+import { WritableStream as Parser } from "htmlparser2/WritableStream";
 import nodePath from "path";
 
 const ignoredRels = new Set(["nofollow", "enclosure", "external"]);

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@marko/run-explorer": "^2.0.0",
-    "@marko/vite": "^5.1.1",
+    "@marko/vite": "^5.1.7",
     "browserslist": "^4.24.4",
     "cli-table3": "^0.6.5",
     "compression": "^1.8.0",


### PR DESCRIPTION
## Description
* Htmlparser2 is being used by marko run static adaptor but its being provided by marko/vite (ideally this should be a dependency of this). htmlparsre2 updated its paths in version 10, but version 9 is being used here. When upgrading marko/vite to the latest it breaks.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
