### PR TITLE
Replace Playwright with in-process browser emulation

### DIFF
--- a/.changeset/static-crawler-flush.md
+++ b/.changeset/static-crawler-flush.md
@@ -1,0 +1,5 @@
+---
+"@marko/run-adapter-static": patch
+---
+
+Fix a race where the build could complete before crawled pages were fully written to disk, intermittently causing missing or truncated files in the static output.

--- a/.changeset/tidy-pugs-repair.md
+++ b/.changeset/tidy-pugs-repair.md
@@ -1,0 +1,6 @@
+---
+"@marko/run": patch
+"@marko/run-adapter-netlify": patch
+---
+
+Remove Playwright from the test suite in favor of an in-process jsdom test browser, and make dev/preview server shutdown reliable — faster, less flaky tests.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Use node
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 26
           cache: npm
       - name: Install dependencies
         run: npm i npm@11.6.0 -g && npm ci
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node: [20, 22, 24]
+        node: [22, 24, 26]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -45,8 +45,6 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm i npm@11.6.0 -g && npm ci
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps chromium
       - name: Run tests
         run: npm run "@ci:test"
       - name: Report code coverage
@@ -67,7 +65,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 26
           cache: npm
       - name: Install dependencies
         run: npm i npm@11.6.0 -g && npm ci

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,5 +1,7 @@
 {
   "exit": true,
+  "no-warnings": true,
+  "experimental-vm-modules": true,
   "timeout": 20000,
   "extension": ["js", "ts", "marko"],
   "spec": ["packages/**/src/**/*.test.@(js|ts)"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "mocha-snap": "^5.0.1",
         "netlify-cli": "^24.10.0",
         "oxc-parser": "^0.136.0",
-        "playwright": "1.61.0",
         "prettier": "^3.8.4",
         "prettier-plugin-packagejson": "^3.0.2",
         "pretty-format": "^30.4.1",
@@ -6948,21 +6947,6 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -14511,6 +14495,381 @@
         }
       }
     },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
     "node_modules/netlify-cli/node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
       "dev": true,
@@ -17754,6 +18113,19 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/fsevents": {
+      "version": "2.3.3",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/netlify-cli/node_modules/function-bind": {
@@ -21538,6 +21910,53 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/netlify-cli/node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/netlify-cli/node_modules/router": {
       "version": "2.2.0",
       "dev": true,
@@ -23839,38 +24258,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/playwright": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
-      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.61.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
-      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/postcss": {
@@ -26460,9 +26847,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "mocha-snap": "^5.0.1",
     "netlify-cli": "^24.10.0",
     "oxc-parser": "^0.136.0",
-    "playwright": "1.61.0",
     "prettier": "^3.8.4",
     "prettier-plugin-packagejson": "^3.0.2",
     "pretty-format": "^30.4.1",

--- a/packages/adapters/netlify/src/index.ts
+++ b/packages/adapters/netlify/src/index.ts
@@ -1,4 +1,7 @@
-import baseAdapter, { type Adapter } from "@marko/run/adapter";
+import baseAdapter, {
+  type Adapter,
+  closeSpawnedProcess,
+} from "@marko/run/adapter";
 import { execSync, spawn } from "child_process";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -86,6 +89,7 @@ export default function netlifyAdapter(options: Options = {}): Adapter {
           ? { ...process.env, DENO_TLS_CA_STORE: "mozilla,system" }
           : process.env,
         shell: true,
+        detached: process.platform !== "win32",
       });
 
       if (process.env.NODE_ENV !== "test") {
@@ -96,8 +100,7 @@ export default function netlifyAdapter(options: Options = {}): Adapter {
       return {
         port,
         close() {
-          proc.unref();
-          proc.kill();
+          return closeSpawnedProcess(proc);
         },
       };
     },

--- a/packages/adapters/static/src/crawler.ts
+++ b/packages/adapters/static/src/crawler.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import { WritableStream as Parser } from "htmlparser2/WritableStream";
 import nodePath from "path";
+import { finished } from "stream/promises";
 
 const ignoredRels = new Set(["nofollow", "enclosure", "external"]);
 
@@ -126,8 +127,11 @@ export default function createCrawler(
         );
       }
     } finally {
-      pageWriter?.end();
       parser.end();
+      if (pageWriter) {
+        pageWriter.end();
+        await finished(pageWriter);
+      }
     }
   }
 

--- a/packages/run/src/__tests__/fixtures/all-http-verbs/test.config.ts
+++ b/packages/run/src/__tests__/fixtures/all-http-verbs/test.config.ts
@@ -14,8 +14,8 @@ export const steps: Step[] = [
 function assertBody(method: string): Step {
   return async ({ page }) => {
     const url = new URL(page.url());
-    const response = await page.request.fetch(url.href, { method });
-    assert.equal(response.ok(), true, `Response for ${method} is not ok`);
+    const response = await page.fetch(url.href, { method });
+    assert.equal(response.ok, true, `Response for ${method} is not ok`);
     const body = await response.text();
     assert.equal(
       body,
@@ -28,8 +28,8 @@ function assertBody(method: string): Step {
 function assertNoBody(method: string): Step {
   return async ({ page }) => {
     const url = new URL(page.url());
-    const response = await page.request.fetch(url.href, { method });
-    assert.equal(response.ok(), true, `Response for ${method} is not ok`);
+    const response = await page.fetch(url.href, { method });
+    assert.equal(response.ok, true, `Response for ${method} is not ok`);
     const body = await response.text();
     assert.equal(
       body,

--- a/packages/run/src/__tests__/fixtures/basic-cookies/test.config.ts
+++ b/packages/run/src/__tests__/fixtures/basic-cookies/test.config.ts
@@ -5,13 +5,11 @@ import { Step, StepContext } from "../../main.test";
 export const steps: Step[] = [(ctx) => readCookies(ctx)];
 
 async function readCookies({ response, page }: StepContext) {
-  const expected = JSON.parse(await page.innerText("#app"));
+  const expected = JSON.parse(page.innerText("#app"));
   const actual: string[] = [];
-  for (const { name, value } of await response.headersArray()) {
-    if (name === "set-cookie") {
-      if (value.startsWith("marko-run-client-id=")) continue;
-      actual.push(value);
-    }
+  for (const value of response.headers.getSetCookie()) {
+    if (value.startsWith("marko-run-client-id=")) continue;
+    actual.push(value);
   }
   assert.deepEqual(actual, expected);
 }

--- a/packages/run/src/__tests__/fixtures/default-get-as-head/test.config.ts
+++ b/packages/run/src/__tests__/fixtures/default-get-as-head/test.config.ts
@@ -8,9 +8,8 @@ export const steps = [
 
 async function requestHead({ page }: StepContext) {
   const url = new URL(page.url());
-  const response = await page.request.fetch(url.href, { method: 'HEAD' });
-  const headers = response.headers();
-  assert.equal(response.ok(), true);
-  assert.match(headers['content-type'], /text\/html/);
-  assert.equal(await response.body(), '');
+  const response = await page.fetch(url.href, { method: 'HEAD' });
+  assert.equal(response.ok, true);
+  assert.match(response.headers.get('content-type')!, /text\/html/);
+  assert.equal(await response.text(), '');
 }

--- a/packages/run/src/__tests__/fixtures/node-adapter-express-bodyParser/test.config.ts
+++ b/packages/run/src/__tests__/fixtures/node-adapter-express-bodyParser/test.config.ts
@@ -18,9 +18,12 @@ async function submitPost({ page }: StepContext) {
     {} as Record<string, string>,
   );
 
-  const response = await page.request.post(page.url(), { form });
+  const response = await page.fetch(page.url(), {
+    method: "POST",
+    body: new URLSearchParams(form),
+  });
 
-  assert.equal(response.ok(), false);
+  assert.equal(response.ok, false);
   assert.match(
     await response.text(),
     /The request body stream has been destroyed or consumed by something before Marko Run/,

--- a/packages/run/src/__tests__/fixtures/node-adapter-express-formData/test.config.ts
+++ b/packages/run/src/__tests__/fixtures/node-adapter-express-formData/test.config.ts
@@ -17,9 +17,12 @@ async function submitPost({ page }: StepContext) {
     {} as Record<string, string>,
   );
 
-  const response = await page.request.post(page.url(), { form });
+  const response = await page.fetch(page.url(), {
+    method: "POST",
+    body: new URLSearchParams(form),
+  });
 
-  assert.equal(response.ok(), true);
+  assert.equal(response.ok, true);
 
   const json = await response.json();
   const actual = json.formData;

--- a/packages/run/src/__tests__/fixtures/post-get-single-flight/test.config.ts
+++ b/packages/run/src/__tests__/fixtures/post-get-single-flight/test.config.ts
@@ -4,5 +4,5 @@ export const path = "/123";
 export const steps: Step[] = [(ctx) => clickSubmit(ctx)];
 
 async function clickSubmit({ page }: StepContext) {
-  await page.locator("button").click();
+  await page.click("button");
 }

--- a/packages/run/src/__tests__/fixtures/post-render-get/test.config.ts
+++ b/packages/run/src/__tests__/fixtures/post-render-get/test.config.ts
@@ -5,15 +5,13 @@ import { Step, StepContext } from "../../main.test";
 export const steps: Step[] = [post];
 
 async function post({ page }: StepContext) {
-  const url = new URL(page.url());
-  const response = await page.request.fetch(url.href, {
-    method: "post",
-    timeout: 0
+  const response = await page.fetch(page.url(), {
+    method: "POST",
   });
-  assert.equal(response.ok(), true, "Post failed");
-  assert.equal(response.status(), 200);
+  assert.equal(response.ok, true, "Post failed");
+  assert.equal(response.status, 200);
 
   const text = await response.text();
 
-  assert.match(text, /<div id=app>POST<\/div>/)
+  assert.match(text, /<div id=app>POST<\/div>/);
 }

--- a/packages/run/src/__tests__/fixtures/request-body-form/test.config.ts
+++ b/packages/run/src/__tests__/fixtures/request-body-form/test.config.ts
@@ -5,18 +5,16 @@ import { Step, StepContext } from "../../main.test";
 export const steps: Step[] = [post];
 
 async function post({ page }: StepContext) {
-  const url = new URL(page.url());
-  const response = await page.request.fetch(url.href, {
-    method: "post",
-    form: {
+  const response = await page.fetch(page.url(), {
+    method: "POST",
+    body: new URLSearchParams({
       name: "MarkoRun",
-      age: 7
-    },
-    timeout: 0
+      age: "7",
+    }),
   });
-  assert.equal(response.ok(), true, "Post failed");
+  assert.equal(response.ok, true, "Post failed");
 
   const json = await response.json();
 
-  assert.equal(json.issues, null)
+  assert.equal(json.issues, null);
 }

--- a/packages/run/src/__tests__/fixtures/request-body-json/test.config.ts
+++ b/packages/run/src/__tests__/fixtures/request-body-json/test.config.ts
@@ -5,18 +5,17 @@ import { Step, StepContext } from "../../main.test";
 export const steps: Step[] = [post];
 
 async function post({ page }: StepContext) {
-  const url = new URL(page.url());
-  const response = await page.request.fetch(url.href, {
-    method: "post",
-    data: {
+  const response = await page.fetch(page.url(), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
       name: "MarkoRun",
-      age: 7
-    },
-    timeout: 0
+      age: 7,
+    }),
   });
-  assert.equal(response.ok(), true, "Post failed");
+  assert.equal(response.ok, true, "Post failed");
 
   const json = await response.json();
 
-  assert.equal(json.issues, null)
+  assert.equal(json.issues, null);
 }

--- a/packages/run/src/__tests__/fixtures/request-body-multipart/test.config.ts
+++ b/packages/run/src/__tests__/fixtures/request-body-multipart/test.config.ts
@@ -5,23 +5,21 @@ import { Step, StepContext } from "../../main.test";
 export const steps: Step[] = [post];
 
 async function post({ page }: StepContext) {
-  const url = new URL(page.url());
-  const response = await page.request.fetch(url.href, {
-    method: "post",
-    multipart: {
-      name: "MarkoRun",
-      age: 7,
-      file: {
-        name: "file.txt",
-        mimeType: "text/plain",
-        buffer: Buffer.from('hello\nworld\n', 'utf8')
-      }
-    },
-    timeout: 0
+  const body = new FormData();
+  body.append("name", "MarkoRun");
+  body.append("age", "7");
+  body.append(
+    "file",
+    new File(["hello\nworld\n"], "file.txt", { type: "text/plain" }),
+  );
+
+  const response = await page.fetch(page.url(), {
+    method: "POST",
+    body,
   });
-  assert.equal(response.ok(), true, "Post failed");
+  assert.equal(response.ok, true, "Post failed");
 
   const json = await response.json();
 
-  assert.equal(json.issues, null)
+  assert.equal(json.issues, null);
 }

--- a/packages/run/src/__tests__/fixtures/shared-handler-reuse/test.config.ts
+++ b/packages/run/src/__tests__/fixtures/shared-handler-reuse/test.config.ts
@@ -6,11 +6,8 @@ export const steps: Step[] = [post];
 
 async function post({ page }: StepContext) {
   const url = new URL(page.url());
-  const response = await page.request.fetch(url.href, {
-    method: "post",
-    timeout: 0,
-  });
-  assert.equal(response.ok(), true, "POST failed");
+  const response = await page.fetch(url.href, { method: "post" });
+  assert.equal(response.ok, true, "POST failed");
   const body = await response.text();
   assert.equal(body, "POST ok");
 }

--- a/packages/run/src/__tests__/fixtures/ssr-emit-assets/test.config.ts
+++ b/packages/run/src/__tests__/fixtures/ssr-emit-assets/test.config.ts
@@ -8,7 +8,7 @@ export const steps = [];
 
 export const assert_preview: Assert = async (page, block) =>  {
   await block();
-  const fileSrc = await page.getByRole("article").innerText()
+  const fileSrc = page.innerText("article")
   const filePath = path.join(process.cwd(), "dist", "public", fileSrc)
   assert.equal(fs.existsSync(filePath), true, `Asset ${fileSrc} was not written to dist`);
 }

--- a/packages/run/src/__tests__/fixtures/static-adapter-file-plain/__snapshots__/dev.expected.md
+++ b/packages/run/src/__tests__/fixtures/static-adapter-file-plain/__snapshots__/dev.expected.md
@@ -1,6 +1,6 @@
 # Loading
 
 ```
-<html><head><meta name="color-scheme" content="light dark"></head><body><pre style="word-wrap: break-word; white-space: pre-wrap;"># Hello World</pre></body></html>
+# Hello World
 ```
 

--- a/packages/run/src/__tests__/fixtures/static-adapter-file-plain/__snapshots__/preview.expected.md
+++ b/packages/run/src/__tests__/fixtures/static-adapter-file-plain/__snapshots__/preview.expected.md
@@ -1,6 +1,6 @@
 # Loading
 
 ```
-<html><head><meta name="color-scheme" content="light dark"></head><body><pre style="word-wrap: break-word; white-space: pre-wrap;"># Hello World</pre></body></html>
+# Hello World
 ```
 

--- a/packages/run/src/__tests__/fixtures/verb-specific-middleware/test.config.ts
+++ b/packages/run/src/__tests__/fixtures/verb-specific-middleware/test.config.ts
@@ -5,14 +5,12 @@ import { Step, StepContext } from "../../main.test";
 export const steps: Step[] = [post];
 
 async function post({ page }: StepContext) {
-  const url = new URL(page.url());
-  const response = await page.request.fetch(url.href, {
-    method: "post",
-    timeout: 0
+  const response = await page.fetch(page.url(), {
+    method: "POST",
   });
-  assert.equal(response.ok(), true, "Post failed");
+  assert.equal(response.ok, true, "Post failed");
 
   const json = await response.json();
 
-  assert.equal(json.foo, 1)
+  assert.equal(json.foo, 1);
 }

--- a/packages/run/src/__tests__/main.test.ts
+++ b/packages/run/src/__tests__/main.test.ts
@@ -5,12 +5,12 @@ import { JSDOM } from "jsdom";
 import snap from "mocha-snap";
 import { createRequire } from "module";
 import path from "path";
-import * as playwright from "playwright";
 import { fileURLToPath } from "url";
 
 import * as cli from "../cli/commands";
 import type { Options } from "../vite";
 import { SpawnedServer, waitForServer } from "../vite/utils/server";
+import { BrowserPage } from "./utils/browser";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = process.cwd();
@@ -21,145 +21,30 @@ Function.prototype.toString = function () {
   return toString.call(this).replace(/\b__name\(([^,]+),[^)]+\)/g, "$1");
 };
 
-declare global {
-  const page: playwright.Page;
-  namespace NodeJS {
-    interface Global {
-      page: playwright.Page;
-    }
-  }
-}
-
-declare namespace globalThis {
-  let page: playwright.Page;
-}
-
-declare let __loading__: Promise<void> | undefined;
-
 export type StepContext = {
-  page: playwright.Page;
-  response: playwright.Response;
+  page: BrowserPage;
+  response: Response;
 };
 export type Step = (context: StepContext) => Promise<unknown> | unknown;
 export type Assert = (
-  page: playwright.Page,
+  page: BrowserPage,
   fn: () => Promise<void>,
 ) => Promise<void>;
 
 const requireCwd = createRequire(root);
-let browser: playwright.Browser;
-let context: playwright.BrowserContext;
+let page: BrowserPage;
 
-before(async () => {
+before(() => {
   process.env.TRUST_PROXY = "1";
-
-  browser = await playwright.chromium.launch();
-  context = await browser.newContext();
-
-  await context.addInitScript(() => {
-    // needed for esbuild.
-    (window as any).__name = (v: any) => v;
-    __loading__ = undefined;
-
-    const seen = new Set<string>();
-    let remaining = 0;
-    let resolve: undefined | (() => void);
-    window.addEventListener("error", onError);
-    window.addEventListener("unhandledrejection", onError);
-    onMutate(document, (_, obs) => {
-      if (!document.body) return;
-      obs.disconnect();
-      trackAssets();
-      onMutate(document.body, trackAssets);
-    });
-
-    function onMutate(target: Node, fn: MutationCallback) {
-      new MutationObserver(fn).observe(target, {
-        childList: true,
-        subtree: true,
-      });
-    }
-    function trackAssets() {
-      for (const el of document.querySelectorAll<
-        HTMLScriptElement | HTMLLinkElement
-      >("script[src],link[rel=stylesheet][href]")) {
-        const href = "src" in el ? el.src : el.href;
-        if (href && !seen.has(href)) {
-          const link = document.createElement("link");
-          __loading__ ||= new Promise((r) => (resolve = r));
-          seen.add(href);
-          remaining++;
-
-          if ("src" in el) {
-            if (el.getAttribute("type") === "module") {
-              link.rel = "modulepreload";
-            } else {
-              link.rel = "preload";
-              link.as = "script";
-            }
-          } else {
-            link.rel = "preload";
-            link.as = "style";
-          }
-
-          link.href = href;
-          link.onload = link.onerror = () => {
-            link.onload = link.onerror = null;
-            link.remove();
-            seen.delete(href);
-            if (!--remaining) {
-              resolve?.();
-              resolve = __loading__ = undefined;
-            }
-          };
-          document.head.append(link);
-        }
-      }
-    }
-    function onError(ev: ErrorEvent | PromiseRejectionEvent) {
-      const msg =
-        ev instanceof PromiseRejectionEvent
-          ? `${ev.reason}\n`
-          : `${ev.error || `Error loading ${(ev.target as any).outerHTML}`}\n`;
-      if (!msg.includes("WebSocket closed")) {
-        let errorContainer = document.getElementById("error");
-        if (!errorContainer) {
-          errorContainer = document.createElement("pre");
-          errorContainer.id = "error";
-          (document.getElementById("app") || document.body).appendChild(
-            errorContainer,
-          );
-        }
-        errorContainer.insertAdjacentText("beforeend", msg);
-      }
-    }
-  });
 });
 
-after(async () => {
-  await browser.close();
-});
-
-async function getHTML() {
+async function getHTML(settle = true) {
+  if (settle) await page.settle();
+  const { document } = page;
   return defaultSerializer(
     defaultNormalizer(
       JSDOM.fragment(
-        await page.evaluate(async () => {
-          do {
-            await __loading__;
-            await new Promise((r) => {
-              requestAnimationFrame(() => {
-                const { port1, port2 } = new MessageChannel();
-                port1.onmessage = r;
-                port2.postMessage(0);
-              });
-            });
-          } while (__loading__);
-
-          return (
-            (document.getElementById("app") || document.body)?.innerHTML || ""
-          );
-        }),
+        (document.getElementById("app") || document.body)?.innerHTML || "",
       ),
     ),
   )
@@ -204,8 +89,8 @@ for (const fixture of fs.readdirSync(FIXTURES)) {
   };
 
   describe(fixture, function () {
-    beforeEach(async () => {
-      globalThis.page = await context.newPage();
+    beforeEach(() => {
+      page = new BrowserPage();
     });
 
     afterEach(async () => {
@@ -286,7 +171,7 @@ for (const fixture of fs.readdirSync(FIXTURES)) {
 }
 
 async function testPage(
-  page: playwright.Page,
+  page: BrowserPage,
   dir: string,
   pathname: string,
   steps: Step[],
@@ -304,21 +189,20 @@ async function testPage(
     const stepContext = { page } as StepContext;
     await waitForServer(server.port);
 
-    stepContext.response = (await page.goto(url.href, {
-      referer: referrerUrl?.href,
-      waitUntil: "commit",
-    }))!;
-
     let snapshot = "# Loading\n\n";
     let prevHtml = "";
-    const contentType = await stepContext.response?.headerValue("content-type");
-    if (!contentType || contentType.includes("text/html")) {
-      await page.waitForSelector("body");
-      const initialHtml = await getHTML();
-      snapshot += htmlSnapshot(initialHtml, prevHtml);
-      prevHtml = initialHtml;
+    await page.goto(url.href, {
+      referer: referrerUrl?.href,
+      async onBodyReady() {
+        if (!prevHtml) {
+          prevHtml = await getHTML(false);
+          snapshot += htmlSnapshot(prevHtml);
+        }
+      },
+    });
+    stepContext.response = page.response;
 
-      await stepContext.response.finished();
+    if (page.window) {
       const finalHtml = await getHTML();
       if (finalHtml !== prevHtml) {
         snapshot += htmlSnapshot(finalHtml, prevHtml);
@@ -334,14 +218,11 @@ async function testPage(
         prevHtml = html;
       }
     } else {
-      await stepContext.response.finished();
-      snapshot += `\`\`\`\n${await page.content()}\n\`\`\`\n\n`;
+      snapshot += `\`\`\`\n${await page.response.text()}\n\`\`\`\n\n`;
     }
 
     await snap(snapshot, { ext: ".md", dir });
   } finally {
-    // TODO: figure out why the dev server fails to close sometimes without this wait
-    await delay(50);
     await server.close();
   }
 }
@@ -385,8 +266,4 @@ function htmlSnapshot(html: string, prevHtml?: string) {
     return `\`\`\`diff\n${diff}\n\`\`\`\n\n`;
   }
   return `\`\`\`html\n${html}\n\`\`\`\n\n`;
-}
-
-function delay(ms: number) {
-  return new Promise<void>((resolve) => setTimeout(resolve, ms));
 }

--- a/packages/run/src/__tests__/utils/browser.ts
+++ b/packages/run/src/__tests__/utils/browser.ts
@@ -1,0 +1,502 @@
+import { type DOMWindow, JSDOM, VirtualConsole } from "jsdom";
+import vm from "vm";
+import { MessageChannel as NodeMessageChannel } from "worker_threads";
+
+export interface GotoOptions {
+  referer?: string;
+  onBodyReady?: () => Promise<unknown> | unknown;
+}
+
+export class BrowserPage {
+  declare window?: DOMWindow;
+  declare response: Response;
+
+  #ctx?: vm.Context;
+  #modules = new Map<
+    string,
+    { module: Promise<vm.Module>; evaluated?: Promise<vm.Module> }
+  >();
+  #pendingModules = 0;
+  #onModulesSettled: (() => void)[] = [];
+  #pendingNavigation: Promise<unknown> = Promise.resolve();
+  #seenAssets = new Set<string>();
+
+  get document() {
+    if (!this.window) throw new Error("The page has not loaded a document.");
+    return this.window.document;
+  }
+
+  url() {
+    return this.window ? this.window.location.href : this.response.url;
+  }
+
+  async goto(href: string, options: GotoOptions = {}) {
+    await this.#navigate(
+      href,
+      { headers: options.referer ? { referer: options.referer } : {} },
+      options.onBodyReady,
+    );
+  }
+
+  fetch(href: string | URL, init?: RequestInit) {
+    return fetch(new URL(href, this.url()), init);
+  }
+
+  async click(selector: string) {
+    const el = this.document.querySelector(selector);
+    if (!el) throw new Error(`No element matches ${JSON.stringify(selector)}`);
+    (el as HTMLElement).click();
+    await this.settle();
+  }
+
+  innerText(selector: string) {
+    const el = this.document.querySelector(selector);
+    if (!el) throw new Error(`No element matches ${JSON.stringify(selector)}`);
+    return (el.textContent || "").trim();
+  }
+
+  async settle() {
+    let nav;
+    do {
+      nav = this.#pendingNavigation;
+      await nav;
+    } while (nav !== this.#pendingNavigation);
+    await this.#settleScheduled();
+  }
+
+  async #settleScheduled() {
+    for (let i = 0; i < 3; i++) {
+      await this.#modulesSettled();
+      await this.#animationFrame();
+      await new Promise((resolve) => setTimeout(resolve));
+      await new Promise(setImmediate);
+    }
+  }
+
+  async close() {
+    await this.#pendingNavigation.catch(() => {});
+    this.window?.close();
+    this.window = undefined;
+  }
+
+  async #navigate(
+    href: string,
+    init: RequestInit & { headers: Record<string, string> },
+    onBodyReady?: GotoOptions["onBodyReady"],
+  ) {
+    const response = await fetch(href, {
+      ...init,
+      headers: {
+        accept: "text/html,*/*;q=0.8",
+        ...init.headers,
+      },
+    });
+
+    this.response = response;
+
+    const contentType = response.headers.get("content-type");
+    if (contentType && !contentType.includes("text/html")) {
+      this.window?.close();
+      this.window = undefined;
+      return;
+    }
+
+    await this.#loadDocument(response, onBodyReady);
+  }
+
+  async #loadDocument(
+    response: Response,
+    onBodyReady?: GotoOptions["onBodyReady"],
+  ) {
+    this.window?.close();
+    this.#modules = new Map();
+    this.#pendingModules = 0;
+    this.#seenAssets = new Set();
+
+    const virtualConsole = new VirtualConsole();
+    virtualConsole.on("jsdomError", () => {});
+
+    const dom = new JSDOM("", {
+      url: response.url,
+      runScripts: "dangerously",
+      pretendToBeVisual: true,
+      virtualConsole,
+    });
+    const { window } = dom;
+    this.window = window;
+    this.#ctx = dom.getInternalVMContext();
+    this.#setupWindow(window);
+
+    const { document } = window;
+    const chunks = await readChunks(response);
+
+    let bodyReady = false;
+    const captureInitial = async () => {
+      if (!bodyReady && document.body) {
+        bodyReady = true;
+        await this.#runModuleScripts(window);
+        await onBodyReady?.();
+      }
+    };
+
+    document.open();
+    if (chunks.length > 1) {
+      const writeNextChunk = streamWriter(document, chunks);
+      while (writeNextChunk()) {
+        await captureInitial();
+        await new Promise(setImmediate);
+        if (window !== this.window) return;
+      }
+    } else {
+      document.write(chunks[0] || "");
+      document.close();
+    }
+
+    const refresh = document
+      .querySelector('meta[http-equiv="refresh" i]')
+      ?.getAttribute("content");
+    const refreshUrl = refresh && /url\s*=\s*(.+)\s*$/i.exec(refresh)?.[1];
+    if (refreshUrl) {
+      await this.#navigate(
+        new URL(refreshUrl, response.url).href,
+        { headers: { referer: response.url } },
+        onBodyReady,
+      );
+      return;
+    }
+
+    await this.#runModuleScripts(window);
+    await captureInitial();
+    await this.#checkAssets(window);
+    await this.#settleScheduled();
+  }
+
+  #setupWindow(window: DOMWindow) {
+    window.setImmediate ||= setImmediate;
+    window.MessageChannel ||= NodeMessageChannel as any;
+    window.fetch ||= ((input: any, init?: RequestInit) =>
+      fetch(
+        typeof input === "string" || input instanceof URL
+          ? new URL(input, window.location.href)
+          : input,
+        init,
+      )) as any;
+    for (const key of [
+      "Headers",
+      "Request",
+      "Response",
+      "ReadableStream",
+      "TextDecoder",
+      "TextEncoder",
+    ] as const) {
+      window[key] ||= globalThis[key] as any;
+    }
+
+    window.addEventListener("error", (ev) => {
+      this.#reportError(
+        `${ev.error || `Error loading ${(ev.target as any)?.outerHTML}`}\n`,
+      );
+    });
+
+    window.addEventListener("submit", (ev) => {
+      if (ev.defaultPrevented) return;
+      ev.preventDefault();
+      const form = ev.target as HTMLFormElement;
+      const submitter = (ev as SubmitEvent).submitter;
+      this.#queueNavigation(() => this.#submitForm(form, submitter));
+    });
+    window.addEventListener("click", (ev) => {
+      if (ev.defaultPrevented) return;
+      const anchor = (ev.target as Element).closest?.("a[href]");
+      if (anchor) {
+        ev.preventDefault();
+        this.#queueNavigation(() =>
+          this.#navigate((anchor as HTMLAnchorElement).href, {
+            headers: { referer: this.url() },
+          }),
+        );
+      }
+    });
+  }
+
+  #queueNavigation(nav: () => Promise<unknown>) {
+    this.#pendingNavigation = this.#pendingNavigation.then(nav, nav);
+  }
+
+  async #submitForm(form: HTMLFormElement, submitter?: HTMLElement | null) {
+    const window = this.window!;
+    let data: FormData;
+    try {
+      data = new window.FormData(form, submitter || undefined) as FormData;
+    } catch {
+      data = new window.FormData(form) as FormData;
+    }
+
+    const method = (
+      (submitter?.getAttribute("formmethod") || form.method || "get") as string
+    ).toLowerCase();
+    const url = new URL(
+      submitter?.getAttribute("formaction") ||
+        form.getAttribute("action") ||
+        "",
+      window.location.href,
+    );
+    const referer = this.url();
+
+    if (method === "get") {
+      url.search = new URLSearchParams(data as any).toString();
+      await this.#navigate(url.href, { headers: { referer } });
+    } else {
+      const body =
+        form.enctype === "multipart/form-data"
+          ? data
+          : new URLSearchParams(data as any);
+      await this.#navigate(url.href, {
+        method,
+        body,
+        headers: { referer },
+      });
+    }
+  }
+
+  async #runModuleScripts(window: DOMWindow) {
+    for (const script of [...window.document.querySelectorAll("script")]) {
+      if (window !== this.window) return;
+      if (script.type !== "module") continue;
+      if (script.src) {
+        await this.#importModule(script.src).catch((err) =>
+          this.#reportError(`${err}\n`),
+        );
+      } else if (script.text) {
+        await this.#runInlineModule(
+          script.text,
+          `${window.location.href}#inline`,
+        ).catch((err) => this.#reportError(`${err}\n`));
+      }
+    }
+    await this.#modulesSettled();
+  }
+
+  #getModule(href: string, referrer?: string): Promise<vm.Module> {
+    const url = new URL(href, referrer ?? this.url()).href;
+    let entry = this.#modules.get(url);
+    if (!entry) {
+      this.#pendingModules++;
+      entry = {
+        module: (new URL(url).pathname === "/@vite/client"
+          ? this.#viteClientStub(url)
+          : fetch(url).then(async (res) => {
+              if (!res.ok) {
+                throw new Error(`Failed to load module ${url} (${res.status})`);
+              }
+              return this.#createModule(await res.text(), url);
+            })
+        ).finally(() => this.#moduleDone()),
+      };
+      this.#modules.set(url, entry);
+    }
+    return entry.module;
+  }
+
+  #importModule(href: string, referrer?: string): Promise<vm.Module> {
+    const url = new URL(href, referrer ?? this.url()).href;
+    this.#getModule(url);
+    const entry = this.#modules.get(url)!;
+    return (entry.evaluated ||= (async () => {
+      this.#pendingModules++;
+      try {
+        const mod = await entry.module;
+        if (mod.status === "unlinked") {
+          await mod.link(this.#linker);
+        }
+        await mod.evaluate();
+        return mod;
+      } finally {
+        this.#moduleDone();
+      }
+    })());
+  }
+
+  async #runInlineModule(source: string, identifier: string) {
+    this.#pendingModules++;
+    try {
+      const mod = this.#createModule(source, identifier);
+      await mod.link(this.#linker);
+      await mod.evaluate();
+    } finally {
+      this.#moduleDone();
+    }
+  }
+
+  #linker = (specifier: string, referrer: vm.Module) =>
+    this.#getModule(specifier, referrer.identifier);
+
+  #createModule(source: string, identifier: string) {
+    return new vm.SourceTextModule(source, {
+      context: this.#ctx,
+      identifier,
+      initializeImportMeta(meta) {
+        meta.url = identifier;
+      },
+      importModuleDynamically: ((specifier: string, referrer: vm.Module) =>
+        this.#importModule(specifier, referrer.identifier)) as any,
+    });
+  }
+
+  #moduleDone() {
+    if (!--this.#pendingModules) {
+      const resolvers = this.#onModulesSettled;
+      this.#onModulesSettled = [];
+      for (const resolve of resolvers) resolve();
+    }
+  }
+
+  async #viteClientStub(url: string) {
+    const { window } = this;
+    let ErrorOverlay = window!.customElements.get("vite-error-overlay");
+    if (!ErrorOverlay) {
+      ErrorOverlay = class extends window!.HTMLElement {};
+      window!.customElements.define("vite-error-overlay", ErrorOverlay);
+    }
+    const mod = new vm.SyntheticModule(
+      [
+        "createHotContext",
+        "updateStyle",
+        "removeStyle",
+        "injectQuery",
+        "ErrorOverlay",
+      ],
+      function (this: vm.SyntheticModule) {
+        this.setExport("createHotContext", () => ({
+          accept() {},
+          acceptExports() {},
+          dispose() {},
+          prune() {},
+          on() {},
+          off() {},
+          send() {},
+          invalidate() {},
+        }));
+        this.setExport("updateStyle", () => {});
+        this.setExport("removeStyle", () => {});
+        this.setExport("injectQuery", (url: string) => url);
+        this.setExport("ErrorOverlay", ErrorOverlay);
+      },
+      { context: this.#ctx, identifier: url },
+    );
+    await mod.link(() => {
+      throw new Error("Unexpected import in vite client stub");
+    });
+    await mod.evaluate();
+    return mod;
+  }
+
+  #modulesSettled() {
+    if (this.#pendingModules) {
+      return new Promise<void>((resolve) =>
+        this.#onModulesSettled.push(resolve),
+      );
+    }
+  }
+
+  async #checkAssets(window: DOMWindow) {
+    const checks: Promise<void>[] = [];
+    for (const el of window.document.querySelectorAll<
+      HTMLScriptElement | HTMLLinkElement
+    >("script[src],link[rel=stylesheet][href]")) {
+      const href = "src" in el ? el.src : el.href;
+      if (!href || this.#seenAssets.has(href) || !/^https?:/.test(href)) {
+        continue;
+      }
+      this.#seenAssets.add(href);
+      checks.push(
+        (async () => {
+          try {
+            const res = await fetch(href);
+            await res.arrayBuffer();
+            if (!res.ok) throw new Error();
+          } catch {
+            this.#reportError(`Error loading ${el.outerHTML}\n`);
+          }
+        })(),
+      );
+    }
+    await Promise.all(checks);
+  }
+
+  #animationFrame() {
+    const { window } = this;
+    if (!window) return;
+    return new Promise((resolve) => window.requestAnimationFrame(resolve));
+  }
+
+  #reportError(msg: string) {
+    const document = this.window?.document;
+    if (!document || msg.includes("WebSocket closed")) return;
+    let errorContainer = document.getElementById("error");
+    if (!errorContainer) {
+      errorContainer = document.createElement("pre");
+      errorContainer.id = "error";
+      (document.getElementById("app") || document.body).appendChild(
+        errorContainer,
+      );
+    }
+    errorContainer.insertAdjacentText("beforeend", msg);
+  }
+}
+
+async function readChunks(response: Response) {
+  const chunks: string[] = [];
+  if (response.body) {
+    const decoder = new TextDecoder();
+    let pending = "";
+    for await (const raw of response.body) {
+      pending += decoder.decode(raw, { stream: true });
+      if (pending.endsWith(">")) {
+        chunks.push(pending);
+        pending = "";
+      }
+    }
+    pending += decoder.decode();
+    if (pending) chunks.push(pending);
+  }
+  return chunks;
+}
+
+function streamWriter(document: Document, chunks: string[]) {
+  const FLUSH = "%%FLUSH%%";
+  const parsed = document.implementation.createHTMLDocument();
+  parsed.write(chunks.join(`<!--${FLUSH}-->`));
+  parsed.doctype?.remove();
+
+  const walker = parsed.createTreeWalker(parsed);
+  const targetNodes = new WeakMap<Node, Node>([[parsed, document]]);
+  let node: Node | null;
+
+  return () => {
+    while ((node = walker.nextNode())) {
+      if (node.nodeType === 8 && (node as Comment).data === FLUSH) {
+        return true;
+      }
+
+      const isInline = isInlineScript(node);
+      const clone = document.importNode(node, isInline);
+      targetNodes.set(node, clone);
+      (targetNodes.get(node.parentNode!) as ParentNode).appendChild(clone);
+
+      if (isInline && node.firstChild) {
+        walker.nextNode();
+      }
+    }
+    document.close();
+    return false;
+  };
+}
+
+function isInlineScript(node: Node): node is HTMLScriptElement {
+  return (
+    (node as HTMLScriptElement).tagName === "SCRIPT" &&
+    (node as HTMLScriptElement).type !== "module" &&
+    !(node as HTMLScriptElement).src
+  );
+}

--- a/packages/run/src/adapter/index.ts
+++ b/packages/run/src/adapter/index.ts
@@ -9,6 +9,7 @@ import type { ResolvedConfig } from "vite";
 import type { Adapter, ExplorerData } from "../vite";
 import { resolveAdapter as pluginResolveAdapter } from "../vite/plugin";
 import {
+  closeServer,
   getAvailablePort,
   getInspectOptions,
   loadEnv,
@@ -16,6 +17,7 @@ import {
   spawnServer,
   spawnServerWorker,
   waitForWorker,
+  withTimeout,
 } from "../vite/utils/server";
 import { createDevServer, type MarkoRunDev } from "./dev-server";
 import { logInfoBox } from "./utils";
@@ -28,6 +30,7 @@ export {
   type MarkoRunDev,
 } from "./dev-server";
 export type { Adapter, SpawnedServer };
+export { closeServer, closeSpawnedProcess } from "../vite/utils/server";
 export type { NodePlatformInfo } from "./middleware";
 
 export type MarkoRunDevAccessor = () => MarkoRunDev;
@@ -141,8 +144,8 @@ export default function adapter(): Adapter {
         port: address.port,
         async close() {
           await Promise.allSettled([
-            devServer.close(),
-            listener.close(),
+            withTimeout(devServer.close(), 500),
+            closeServer(listener),
             explorer?.close(),
           ]);
         },

--- a/packages/run/src/vite/utils/server.ts
+++ b/packages/run/src/vite/utils/server.ts
@@ -2,6 +2,7 @@ import cp, { type ChildProcess, type StdioOptions } from "child_process";
 import cluster, { type Address, type Worker } from "cluster";
 import { config, parse } from "dotenv";
 import fs from "fs";
+import type { Server } from "http";
 import net, { type Socket } from "net";
 
 export interface SpawnedServer {
@@ -44,16 +45,11 @@ export async function spawnServer(
     shell: true,
     stdio,
     windowsHide: true,
+    detached: process.platform !== "win32",
     env: { ...env, NODE_ENV: "development", ...process.env, PORT: `${port}` },
   });
 
-  const close = async () => {
-    proc.unref();
-    proc.kill();
-    if (!(await waitForExit(proc, 500))) {
-      proc.kill("SIGKILL");
-    }
-  };
+  const close = () => closeSpawnedProcess(proc);
 
   try {
     await Promise.race([waitForError(proc, port), waitForServer(port, wait)]);
@@ -113,13 +109,50 @@ export async function spawnServerWorker(
   }
 }
 
-async function waitForExit(proc: ChildProcess, wait: number = 0) {
-  if (proc.exitCode !== null) return;
+export async function closeSpawnedProcess(proc: ChildProcess) {
+  proc.unref();
+  killTree(proc, "SIGTERM");
+  if (!(await waitForExit(proc, 500))) {
+    killTree(proc, "SIGKILL");
+  }
+}
 
-  return await new Promise<number | null>((resolve) => {
-    (proc.once("exit", resolve), proc.once("close", resolve));
+export function closeServer(server: Server) {
+  return new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+    server.closeAllConnections();
+  });
+}
+
+export function withTimeout<T>(promise: Promise<T>, ms: number) {
+  return Promise.race([
+    promise,
+    new Promise<void>((resolve) => setTimeout(resolve, ms).unref()),
+  ]);
+}
+
+function killTree(proc: ChildProcess, signal: NodeJS.Signals) {
+  if (!proc.pid || proc.exitCode !== null || proc.signalCode) return;
+  if (process.platform === "win32") {
+    cp.spawnSync("taskkill", ["/pid", `${proc.pid}`, "/T", "/F"], {
+      windowsHide: true,
+    });
+  } else {
+    try {
+      process.kill(-proc.pid, signal);
+    } catch {
+      proc.kill(signal);
+    }
+  }
+}
+
+async function waitForExit(proc: ChildProcess, wait: number = 0) {
+  if (proc.exitCode !== null || proc.signalCode) return true;
+
+  return await new Promise<boolean>((resolve) => {
+    proc.once("exit", () => resolve(true));
     if (wait) {
-      setTimeout(resolve, wait, null);
+      setTimeout(resolve, wait, false).unref();
     }
   });
 }
@@ -143,7 +176,7 @@ export async function waitForError(
 export async function waitForServer(
   port: number,
   wait: number = 0,
-): Promise<Socket> {
+): Promise<void> {
   let remaining = wait > 0 ? wait : Infinity;
   let connection: Socket | null;
   while (!(connection = await getConnection(port))) {
@@ -156,7 +189,7 @@ export async function waitForServer(
       );
     }
   }
-  return connection;
+  connection.destroy();
 }
 
 export async function waitForWorker(worker: Worker, port: number) {
@@ -197,7 +230,9 @@ export async function getConnection(port: number): Promise<Socket | null> {
 }
 
 export async function isPortInUse(port: number): Promise<boolean> {
-  return Boolean(await getConnection(port));
+  const connection = await getConnection(port);
+  connection?.destroy();
+  return Boolean(connection);
 }
 
 export async function getAvailablePort(port?: number): Promise<number> {


### PR DESCRIPTION
## Description

Replaces Playwright-based browser testing with a lightweight in-process browser emulation using jsdom and Node's `vm` module. This eliminates the need for spawning a real browser process while maintaining the ability to test server-rendered pages with streaming responses and module script execution.

### Key Changes

- **New `BrowserPage` class** (`packages/run/src/__tests__/utils/browser.ts`): A minimal browser emulation that:
  - Fetches pages from dev/preview servers and streams them into jsdom documents chunk-by-chunk
  - Executes module scripts via `vm.SourceTextModule` with proper linking and evaluation
  - Handles form submissions and link navigation
  - Provides `goto()`, `click()`, `fetch()`, `innerText()`, and `settle()` methods
  - Supports `onBodyReady` callback for observing documents mid-stream
  - Includes a Vite client stub for HMR compatibility

- **Updated test infrastructure** (`packages/run/src/__tests__/main.test.ts`):
  - Removed Playwright dependency and browser context setup
  - Replaced with simple `BrowserPage` instantiation
  - Updated test fixtures to use standard Fetch API instead of Playwright's `page.request`
  - Simplified HTML snapshot logic using `onBodyReady` callback

- **Improved server lifecycle management** (`packages/run/src/vite/utils/server.ts`):
  - Added `closeSpawnedProcess()` to properly terminate spawned servers as a process tree (fixes issues where shell wrapping could leave servers running)
  - Added `closeServer()` for graceful HTTP server shutdown with connection cleanup
  - Improved process signaling for both Unix and Windows platforms

- **Updated test fixtures**: All request-based test configs now use standard Fetch API with `page.fetch()` instead of Playwright's `page.request`

- **CI improvements**: Removed Playwright browser installation step from GitHub Actions

## Motivation and Context

This change addresses several issues:
1. **Reliability**: Playwright browser processes sometimes failed to close properly, leaving orphaned processes
2. **Performance**: Eliminates the overhead of spawning and managing real browser instances for testing
3. **Simplicity**: Reduces external dependencies and makes the test infrastructure more maintainable
4. **Compatibility**: The in-process approach better simulates how streaming responses are actually parsed and executed

The new `BrowserPage` implementation provides sufficient fidelity for testing server-rendered pages with module scripts, form handling, and navigation while being significantly lighter weight than Playwright.

## Checklist

- [x] Tests updated to use new browser emulation
- [x] Server lifecycle management improved for reliability
- [x] CI configuration updated to remove Playwright dependency

https://claude.ai/code/session_013bwGvzHQUNQzKY4kN7hCiq