### PR TITLE
fix: revert context to a plain object so spreading keeps its methods

### DIFF
--- a/.changeset/plain-context-object.md
+++ b/.changeset/plain-context-object.md
@@ -1,0 +1,5 @@
+---
+"@marko/run": patch
+---
+
+Revert context to a plain object so its methods and lazy getters survive being spread into `$global`

--- a/packages/run/src/runtime/internal.ts
+++ b/packages/run/src/runtime/internal.ts
@@ -209,7 +209,7 @@ export function createContext(
           ? route.options.params(route.params as Record<string, any>)
           : route.params
         : {};
-      Object.defineProperty(this, "params", {
+      Object.defineProperty(context, "params", {
         configurable: true,
         enumerable: true,
         value,
@@ -217,11 +217,11 @@ export function createContext(
       return value;
     },
     get search() {
-      const search = searchParamsToObject(this.url.searchParams);
+      const search = searchParamsToObject(url.searchParams);
       const value = route?.options.search
         ? route.options.search(search)
         : search;
-      Object.defineProperty(this, "search", {
+      Object.defineProperty(context, "search", {
         configurable: true,
         enumerable: true,
         value,
@@ -230,13 +230,13 @@ export function createContext(
     },
     async fetch(resource, init) {
       const request = new Request(
-        typeof resource === "string" ? new URL(resource, this.url) : resource,
+        typeof resource === "string" ? new URL(resource, url) : resource,
         init,
       );
 
-      parentContextLookup.set(request, this as any);
+      parentContextLookup.set(request, context);
       return (
-        (await globalThis.__marko_run__.fetch(request, this.platform)) ||
+        (await globalThis.__marko_run__.fetch(request, platform)) ||
         new Response(null, { status: 404 })
       );
     },
@@ -245,7 +245,7 @@ export function createContext(
         toReadable(
           template.render({
             ...input,
-            $global: this as unknown as Marko.Global,
+            $global: context as unknown as Marko.Global,
           }),
         ),
         init,
@@ -264,13 +264,13 @@ export function createContext(
       return new Response(null, {
         status,
         headers: {
-          location: (typeof to === "string" ? new URL(to, this.url) : to).href,
+          location: (typeof to === "string" ? new URL(to, url) : to).href,
         },
       });
     },
     back(fallback = "/", status) {
-      return this.redirect(
-        this.request.headers.get("referer") || fallback,
+      return context.redirect(
+        request.headers.get("referer") || fallback,
         status,
       );
     },

--- a/packages/run/src/runtime/internal.ts
+++ b/packages/run/src/runtime/internal.ts
@@ -180,130 +180,102 @@ async function readBody(route: RouteMatch, context: Context) {
   return validator ? validator(data) : data;
 }
 
-class RuntimeContext implements Context {
-  readonly route: Context["route"];
-  readonly method: Context["method"];
-  readonly meta: Context["meta"];
-  readonly body: Context["body"];
-  readonly data: Context["data"];
-  readonly url: Context["url"];
-  readonly request: Context["request"];
-  readonly platform: Context["platform"];
-  readonly parent: Context["parent"];
-  serializedGlobals: Context["serializedGlobals"];
-
-  private readonly _route;
-
-  constructor(
-    route: RouteMatch | null,
-    request: Request,
-    platform: Platform,
-    url: URL,
-  ) {
-    this._route = route;
-    this.route = route?.path || "";
-    this.method = request.method as HttpVerb;
-    this.meta = route?.meta || {};
-    this.body =
-      route && request.body && (route.options.json || route.options.form)
-        ? thenable(() => readBody(route, this))
-        : undefined;
-    this.data = {};
-    this.url = url;
-    this.request = request;
-    this.platform = platform;
-    this.parent = parentContextLookup.get(request);
-    this.serializedGlobals = {
-      params: true,
-      url: true,
-    };
-  }
-
-  get params() {
-    const value = this._route
-      ? this._route.options.params
-        ? this._route.options.params(this._route.params as Record<string, any>)
-        : this._route.params
-      : {};
-    Object.defineProperty(this, "params", {
-      configurable: true,
-      enumerable: true,
-      value,
-    });
-    return value;
-  }
-
-  get search() {
-    const search = searchParamsToObject(this.url.searchParams);
-    const value = this._route?.options.search
-      ? this._route.options.search(search)
-      : search;
-    Object.defineProperty(this, "search", {
-      configurable: true,
-      enumerable: true,
-      value,
-    });
-    return value;
-  }
-
-  async fetch(resource: string | URL | Request, init?: RequestInit) {
-    const request = new Request(
-      typeof resource === "string" ? new URL(resource, this.url) : resource,
-      init,
-    );
-
-    parentContextLookup.set(request, this as any);
-    return (
-      (await globalThis.__marko_run__.fetch(request, this.platform)) ||
-      new Response(null, { status: 404 })
-    );
-  }
-
-  render<T>(
-    template: Marko.Template<T>,
-    input: T,
-    init: ResponseInit = pageResponseInit,
-  ) {
-    return new Response(
-      toReadable(
-        template.render({
-          ...input,
-          $global: this as unknown as Marko.Global,
-        }),
-      ),
-      init,
-    );
-  }
-
-  redirect(to: string | URL, status = 302) {
-    if (typeof status !== "number") {
-      throw new RangeError(`Invalid status code ${status}`);
-    } else if (status < 301 || status > 308 || (status > 303 && status < 307)) {
-      throw new RangeError(`Invalid status code ${status}`);
-    }
-    return new Response(null, {
-      status,
-      headers: {
-        location: (typeof to === "string" ? new URL(to, this.url) : to).href,
-      },
-    });
-  }
-
-  back(fallback: string | URL = "/", status?: number) {
-    return this.redirect(
-      this.request.headers.get("referer") || fallback,
-      status,
-    );
-  }
-}
-
 export function createContext(
   route: RouteMatch | null,
   request: Request,
   platform: Platform,
   url: URL = new URL(request.url),
 ): Context {
-  return new RuntimeContext(route, request, platform, url);
+  const context: Context = {
+    route: route?.path || "",
+    method: request.method as HttpVerb,
+    meta: route?.meta || {},
+    body:
+      route && request.body && (route.options.json || route.options.form)
+        ? thenable(() => readBody(route, context))
+        : undefined,
+    data: {},
+    url,
+    request,
+    platform,
+    parent: parentContextLookup.get(request),
+    serializedGlobals: {
+      params: true,
+      url: true,
+    },
+    get params() {
+      const value = route
+        ? route.options.params
+          ? route.options.params(route.params as Record<string, any>)
+          : route.params
+        : {};
+      Object.defineProperty(this, "params", {
+        configurable: true,
+        enumerable: true,
+        value,
+      });
+      return value;
+    },
+    get search() {
+      const search = searchParamsToObject(this.url.searchParams);
+      const value = route?.options.search
+        ? route.options.search(search)
+        : search;
+      Object.defineProperty(this, "search", {
+        configurable: true,
+        enumerable: true,
+        value,
+      });
+      return value;
+    },
+    async fetch(resource, init) {
+      const request = new Request(
+        typeof resource === "string" ? new URL(resource, this.url) : resource,
+        init,
+      );
+
+      parentContextLookup.set(request, this as any);
+      return (
+        (await globalThis.__marko_run__.fetch(request, this.platform)) ||
+        new Response(null, { status: 404 })
+      );
+    },
+    render(template, input, init = pageResponseInit) {
+      return new Response(
+        toReadable(
+          template.render({
+            ...input,
+            $global: this as unknown as Marko.Global,
+          }),
+        ),
+        init,
+      );
+    },
+    redirect(to, status = 302) {
+      if (typeof status !== "number") {
+        throw new RangeError(`Invalid status code ${status}`);
+      } else if (
+        status < 301 ||
+        status > 308 ||
+        (status > 303 && status < 307)
+      ) {
+        throw new RangeError(`Invalid status code ${status}`);
+      }
+      return new Response(null, {
+        status,
+        headers: {
+          location: (typeof to === "string" ? new URL(to, this.url) : to).href,
+        },
+      });
+    },
+    back(fallback = "/", status) {
+      return this.redirect(
+        this.request.headers.get("referer") || fallback,
+        status,
+      );
+    },
+  };
+  return context;
 }
 
 export function render<T>(


### PR DESCRIPTION
## Description

`@marko/run`: reverts the runtime request context from a class (`RuntimeContext`) back to a plain object literal built in `createContext` (`packages/run/src/runtime/internal.ts`), the way it was constructed before the validation/data-loading refactor. The context's methods now close over `createContext`'s locals instead of using `this`, so they work even when detached. Everything introduced alongside the class is preserved:

- per-context `serializedGlobals` (not the previously shared module-level object)
- lazy `body` thenable for json/form parsing
- `data`
- lazy, self-caching `params`/`search` getters that run the route's validators

Also adds a changeset (patch bump for `@marko/run`). No type changes.

## Motivation and Context

Marko 6's `Template.render()` spreads `input.$global` into a fresh object (`{ runtimeId, renderId, ...$global }`), and marko-run passes the context as `$global`. With a class-based context, the methods (`fetch`, `render`, `redirect`, `back`) and the `params`/`search` getters lived on the prototype, so they were not own enumerable properties and were silently dropped by that spread — templates saw a `$global` missing `$global.fetch`, `$global.params`, etc. Methods extracted off the context also lost their `this` binding. As own properties of an object literal (with no `this` usage), they survive spreading and unbound calls.

## Screenshots (if appropriate):

N/A

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JymHhNJeQEsm4VbwapsTkK

---
_Generated by [Claude Code](https://claude.ai/code/session_01JymHhNJeQEsm4VbwapsTkK)_