### PR TITLE
fix: avoid Node DEP0190 warning when spawning dev/preview server

### DIFF
--- a/.changeset/spawn-shell-deprecation.md
+++ b/.changeset/spawn-shell-deprecation.md
@@ -1,0 +1,6 @@
+---
+"@marko/run": patch
+"@marko/run-adapter-netlify": patch
+---
+
+Avoid Node's `DEP0190` deprecation warning by joining the command and args into a single string instead of passing an args array alongside `shell: true` when spawning the dev/preview server.

--- a/packages/adapters/netlify/src/index.ts
+++ b/packages/adapters/netlify/src/index.ts
@@ -78,7 +78,9 @@ export default function netlifyAdapter(options: Options = {}): Adapter {
 
       args.push(...parseNetlifyArgs(previewOptions.args));
 
-      const proc = spawn("netlify", args, {
+      // Join the command and args into a single string rather than passing an
+      // args array alongside `shell: true`, which Node deprecates (DEP0190).
+      const proc = spawn(["netlify", ...args].join(" "), {
         cwd,
         env: options.edge
           ? { ...process.env, DENO_TLS_CA_STORE: "mozilla,system" }

--- a/packages/run/src/vite/utils/server.ts
+++ b/packages/run/src/vite/utils/server.ts
@@ -37,7 +37,9 @@ export async function spawnServer(
     env = await parseEnv(env);
   }
 
-  const proc = cp.spawn(cmd, args, {
+  // Join the command and args into a single string rather than passing an
+  // args array alongside `shell: true`, which Node deprecates (DEP0190).
+  const proc = cp.spawn([cmd, ...args].join(" "), {
     cwd,
     shell: true,
     stdio,


### PR DESCRIPTION
## Description

`@marko/run` and `@marko/run-adapter-netlify` spawned child processes with `shell: true` while also passing an args array. This joins the command and args into a single string and drops the array — behavior-identical to what Node did internally.

## Motivation and Context

Fixes the [DEP0190](https://nodejs.org/api/deprecations.html#DEP0190) warning emitted when using `@marko/run`:

> DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BYCixZrEu6T2W4qb3BH7gs)_