### PR TITLE
fix: dev dependency scan and export detection issues

### DIFF
--- a/.changeset/isolated-export-scan.md
+++ b/.changeset/isolated-export-scan.md
@@ -1,0 +1,5 @@
+---
+"@marko/run": patch
+---
+
+Detect script route handler and middleware exports in dev by parsing the file in isolation instead of transforming it through the client environment, which pulled each file's server-only import graph through the browser pipeline and errored on imports only the server environment can resolve (e.g. `cloudflare:workers`). `.marko` handlers still compile through the pipeline before export detection.

--- a/.changeset/scanner-safe-router.md
+++ b/.changeset/scanner-safe-router.md
@@ -1,0 +1,5 @@
+---
+"@marko/run": patch
+---
+
+Exclude the virtual `@marko/run/router` module from dependency optimization in every environment, so an environment that scans a server entry (e.g. a Cloudflare Workers environment) no longer fails its dependency scan trying to load the virtual file from disk.

--- a/packages/run/src/vite/plugin.ts
+++ b/packages/run/src/vite/plugin.ts
@@ -17,6 +17,7 @@ import {
   type ModuleNode,
   type Plugin,
   type ResolvedConfig,
+  transformWithOxc,
   type ViteDevServer,
 } from "vite";
 
@@ -136,6 +137,14 @@ export default function markoRun(opts: Options = {}): Plugin[] {
 
   async function getExportsFromFile(context: PluginContext, filePath: string) {
     if (devServer) {
+      if (/\.[cm]?[jt]sx?$/i.test(filePath)) {
+        // Parsed in isolation: these are server-only files, and transforming
+        // them through a dev environment pulls in their whole import graph.
+        const source = await fs.promises.readFile(filePath, "utf-8");
+        const { code } = await transformWithOxc(source, filePath);
+        return getExportIdentifiers(context.parse(code));
+      }
+      // Anything else (e.g. `.marko`) must compile before it parses as JS.
       const result = await devServer.transformRequest(filePath, { ssr: false });
       return result ? getExportIdentifiers(context.parse(result.code)) : [];
     }

--- a/packages/run/src/vite/plugin.ts
+++ b/packages/run/src/vite/plugin.ts
@@ -546,6 +546,11 @@ export default function markoRun(opts: Options = {}): Plugin[] {
 
         return setExternalPluginOptions(pluginConfig, opts);
       },
+      configEnvironment() {
+        // `@marko/run/router` resolves to a virtual module, so no
+        // environment's dependency scan may load it (or its graph) from disk.
+        return { optimizeDeps: { exclude: ["@marko/run/router"] } };
+      },
       configResolved(config) {
         resolvedConfig = config;
         const {


### PR DESCRIPTION
## Description

Two dev-server fixes in `@marko/run`, one commit each:

- **Exclude the virtual `@marko/run/router` from dependency optimization.** An environment that scans a server entry resolves the router to its virtual filename and then fails the scan trying to load that file from disk, which disables dependency pre-bundling for that environment. Excluded (via `configEnvironment`, so it reaches every environment), the scanner externalizes the specifier and the scan completes.

- **Detect script handler/middleware exports without a dev environment.** In dev, export names were read by transforming route files through the client environment (`transformRequest(file, { ssr: false })`), whose import analysis then eagerly pre-transforms each file's whole import graph in an environment that may not resolve server-only imports (e.g. `cloudflare:workers`). Script files are now read and parsed in isolation (`transformWithOxc` + the existing AST walk); `.marko` handlers keep using the pipeline since they must compile before they parse as JS.

## Motivation and Context

Composing @marko/run with `@cloudflare/vite-plugin` pinned to the `ssr` environment surfaces both on every dev boot: the workerd environment scans the worker entry (which imports `@marko/run/router`) and aborts pre-bundling, and the export scan prints `cloudflare:workers` resolution errors from the client environment. With both fixes, dev boots clean against real workerd-backed environments.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Az6N2kEKaqNeRU7F2cjh6)_