### PR TITLE
Warn about non-routable lookalike route files

### DIFF
--- a/.changeset/lookalike-route-warnings.md
+++ b/.changeset/lookalike-route-warnings.md
@@ -1,0 +1,5 @@
+---
+"@marko/run": patch
+---
+
+Warn in dev and build about route files that look routable but silently are not: a `+type` marker matching no routable type (e.g. `+server.js`, a wrong extension like `+page.txt`, a typo'd `+pge.marko`) points at the routable file list, and a `$param` name missing its `+type` suggests the fix. `[flag]` variant groups (e.g. `@ebay/arc`'s `header[mobile+android].js`, or `+page[mobile].marko`) are ignored so they never read as broken routes. The "no http verb exports" warning also names any lowercase verb-like exports it found (e.g. `get`) and shows the `Run.GET(handler)` form.

--- a/packages/run/src/vite/__tests__/lookalike-warnings.test.ts
+++ b/packages/run/src/vite/__tests__/lookalike-warnings.test.ts
@@ -1,0 +1,66 @@
+import assert from "assert";
+
+import { buildRoutes } from "../routes/builder";
+import { createTestWalker } from "../routes/walk";
+import { createDirectory } from "./utils/fakeFS";
+
+async function collectWarnings(tree: string): Promise<string[]> {
+  const warnings: string[] = [];
+  const original = console.warn;
+  console.warn = (message: string) => warnings.push(message);
+  try {
+    await buildRoutes(
+      { walker: createTestWalker(createDirectory(tree, "/src/routes")) },
+      "/dist/.marko-run",
+    );
+  } finally {
+    console.warn = original;
+  }
+  return warnings;
+}
+
+describe("non-routable lookalike warnings", () => {
+  it("names the convention a botched route file missed", async () => {
+    const warnings = await collectWarnings(`
+      +server.js
+      +pge.marko
+      $id.marko
+    `);
+    assert.match(
+      warnings.find((w) => w.includes("+server.js"))!,
+      /request handlers are named `\+handler\.<ext>`/,
+    );
+    assert.match(
+      warnings.find((w) => w.includes("+pge.marko"))!,
+      /routable files are `\+page\.marko`/,
+    );
+    assert.match(
+      warnings.find((w) => w.includes("$id.marko"))!,
+      /route files need a `\+type` suffix/,
+    );
+  });
+
+  it("does not flag @ebay/arc variant files or bracket directories", async () => {
+    // arc names adaptive variants `file[flag].ext` (flags combine with `+`) and
+    // can bracket directories, so none of these may read as broken routes.
+    const warnings = await collectWarnings(`
+      +page.marko
+      +page[mobile].marko
+      header[mobile+android].js
+      logo[ebay].svg
+      /date-picker[experiment]
+        +page.marko
+    `);
+    assert.deepEqual(warnings, []);
+  });
+
+  it("does not flag valid routes", async () => {
+    const warnings = await collectWarnings(`
+      +page.marko
+      /products
+        /$id
+          +page.marko
+    `);
+    assert.deepEqual(warnings, []);
+  });
+});

--- a/packages/run/src/vite/plugin.ts
+++ b/packages/run/src/vite/plugin.ts
@@ -297,8 +297,17 @@ export default function markoRun(opts: Options = {}): Plugin[] {
               }
             }
             if (!route.handler.verbs.length) {
+              const nearMisses = exports.filter(
+                (name) =>
+                  name !== name.toUpperCase() &&
+                  httpVerbs.includes(name.toLowerCase() as HttpVerb),
+              );
               context.warn(
-                `Did not find any http verb exports in ${path.relative(root, route.handler.filePath)} - expected ${httpVerbs.map((v) => v.toUpperCase()).join(", ")}`,
+                `Did not find any http verb exports in ${path.relative(root, route.handler.filePath)} - expected ${httpVerbs.map((v) => v.toUpperCase()).join(", ")}${
+                  nearMisses.length
+                    ? `. Found \`${nearMisses.join("`, `")}\` - verb exports must be uppercase, e.g. \`export const ${nearMisses[0].toUpperCase()} = Run.${nearMisses[0].toUpperCase()}(handler)\``
+                    : ""
+                }`,
               );
             }
           }

--- a/packages/run/src/vite/routes/builder.ts
+++ b/packages/run/src/vite/routes/builder.ts
@@ -23,6 +23,42 @@ export function isRoutableFile(filename: string) {
   return RoutableFileRegex.test(filename);
 }
 
+// @ebay/arc names adaptive variants `file[flag].ext` (flags combine with `+`,
+// e.g. `header[mobile+android].js`) and can bracket directories too. Strip those
+// groups before classifying so their brackets and `+` never read as routes.
+const bracketFlagReg = /\[[^\]]*\]/g;
+
+function warnLookalike(message: string): void {
+  console.warn(`[marko-run] ${message}`);
+}
+
+// Warn (dev and build) about files that look like a botched route — a `+type`
+// marker matching no routable type, or a `$param` name missing its `+type` —
+// but silently are not routable. Brackets alone are never flagged: they aren't
+// Marko Run syntax (a `[id]` segment is just a literal), and arc gives them
+// meaning.
+function warnNonRoutableLookalike(name: string, filePath: string): void {
+  // `+page[mobile].marko` is arc's variant of a real `+page.marko`, not a break.
+  const base = name.replace(bracketFlagReg, "");
+  if (RoutableFileRegex.test(base)) return;
+
+  const relativeFilePath = path.relative(process.cwd(), filePath);
+  if (base.includes("+")) {
+    const hint = /^\+server\./i.test(base)
+      ? "request handlers are named `+handler.<ext>`"
+      : "routable files are `+page.marko`, `+layout.marko`, `+handler.*`, `+middleware.*`, `+meta.*`, `+404.marko` and `+500.marko`";
+    warnLookalike(`${relativeFilePath} is not routable; ${hint}.`);
+  } else if (base[0] === "$") {
+    const stem = base.replace(/\.[^.]+$/, "");
+    const suggestion = /\.marko$/i.test(base)
+      ? `${stem}+page.marko`
+      : `${stem}+handler${base.slice(base.lastIndexOf("."))}`;
+    warnLookalike(
+      `${relativeFilePath} is not routable; route files need a \`+type\` suffix after their path segments, e.g. \`${suggestion}\`.`,
+    );
+  }
+}
+
 export function matchRoutableFile(filename: string) {
   const match = filename.match(RoutableFileRegex);
   return match && ((match[1] || match[3]).toLowerCase() as RoutableFileType);
@@ -86,6 +122,7 @@ export async function buildRoutes(
       const { name } = file;
       const match = name.match(RoutableFileRegex);
       if (!match) {
+        warnNonRoutableLookalike(name, file.path);
         return;
       }
 


### PR DESCRIPTION
## Description

`@marko/run`: route files that look routable but silently are not now get dev/build warnings naming the convention they missed:

- A `+type` marker matching no routable type — `+server.js`, a wrong extension like `+page.txt`, a typo'd `+pge.marko` — points at the routable file list (or the `+handler.<ext>` hint for `+server.*`).
- A `$param`-style name missing its `+type` suffix → e.g. `$id+page.marko`.
- The existing "no http verb exports" warning now names any lowercase verb-like exports it found (e.g. `get`) and shows the `export const GET = Run.GET(handler)` form.

`[flag]` variant groups are stripped before classifying, so [`@ebay/arc`](https://github.com/ebay/arc) files — `header[mobile+android].js`, or `+page[mobile].marko` as an adaptive variant of a real `+page.marko` — never read as broken routes. Brackets alone are never flagged: they aren't Marko Run syntax (a `[id]` segment is just a literal), and arc gives them meaning. Valid routes never warn.

Warnings route through a single `warnLookalike` seam so the cheat-sheet pointer can be threaded in agent-gated (#212).

## Motivation and Context

These shapes (SvelteKit/Next habits, typos) previously produced silent 404s with no signal anywhere — the file is simply not routable. Naming the nearest convention at the moment the mistake is made turns a dead end into a one-step fix.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZUGLZL3YoBToFLSEv2Nys