### PR TITLE
fix: pkg-toggle round-trip losing toggle-only keys; make `npm run lint` pass on a clean checkout

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -29,6 +29,8 @@
     "mware",
     "postable",
     "renderable",
+    "formaction",
+    "formmethod",
     "domcontentloaded",
     "requestfinished",
     "requestfailed",
@@ -37,7 +39,8 @@
     "vdir",
     "Broutes",
     "Freadme",
-    "quasis"
+    "quasis",
+    "taskkill"
   ],
   "ignoreRegExpList": [],
   "files": ["*", "src/**/*"],

--- a/packages/run/src/__tests__/pkg-toggle.test.ts
+++ b/packages/run/src/__tests__/pkg-toggle.test.ts
@@ -1,0 +1,83 @@
+import assert from "assert";
+import { execFileSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import url from "url";
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const script = path.join(__dirname, "../../../../scripts/pkg-toggle.js");
+
+const packageData = {
+  name: "fixture",
+  version: "1.0.0",
+  exports: { ".": "./src/index.ts" },
+  types: "./src/index.ts",
+};
+
+// `typesVersions` exists only on the toggle side: it must migrate into
+// package.json for a release and back off of it afterward.
+const toggleData = {
+  exports: { ".": "./dist/index.js" },
+  types: "./dist/index.d.ts",
+  typesVersions: { "*": { "*": ["./dist/index.d.ts"] } },
+};
+
+describe("pkg-toggle", () => {
+  let dir: string;
+  let packageFile: string;
+  let toggleFile: string;
+
+  const read = (file: string) => JSON.parse(fs.readFileSync(file, "utf8"));
+  const toggle = () =>
+    execFileSync(process.execPath, [script], {
+      cwd: dir,
+      // The test env's `--import tsx` cannot resolve from the temp dir.
+      env: { ...process.env, NODE_OPTIONS: "" },
+    });
+
+  before(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "pkg-toggle-"));
+    const pkgDir = path.join(dir, "packages", "fixture");
+    fs.mkdirSync(pkgDir, { recursive: true });
+    fs.mkdirSync(path.join(dir, "packages", "adapters"), { recursive: true });
+    packageFile = path.join(pkgDir, "package.json");
+    toggleFile = path.join(pkgDir, "package.toggle.json");
+    fs.writeFileSync(packageFile, JSON.stringify(packageData, null, 2) + "\n");
+    fs.writeFileSync(toggleFile, JSON.stringify(toggleData, null, 2) + "\n");
+  });
+
+  after(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("round-trips toggle-only keys across two runs", () => {
+    toggle();
+    assert.deepEqual(read(packageFile), {
+      name: "fixture",
+      version: "1.0.0",
+      exports: toggleData.exports,
+      types: toggleData.types,
+      typesVersions: toggleData.typesVersions,
+    });
+    // The absent-on-package.json key survives as an explicit null marker.
+    assert.deepEqual(read(toggleFile), {
+      exports: packageData.exports,
+      types: packageData.types,
+      typesVersions: null,
+    });
+
+    toggle();
+    assert.deepEqual(read(packageFile), packageData);
+    assert.deepEqual(read(toggleFile), toggleData);
+  });
+
+  it("is byte-stable across further toggle cycles", () => {
+    const packageBytes = fs.readFileSync(packageFile, "utf8");
+    const toggleBytes = fs.readFileSync(toggleFile, "utf8");
+    toggle();
+    toggle();
+    assert.equal(fs.readFileSync(packageFile, "utf8"), packageBytes);
+    assert.equal(fs.readFileSync(toggleFile, "utf8"), toggleBytes);
+  });
+});

--- a/scripts/pkg-toggle.js
+++ b/scripts/pkg-toggle.js
@@ -1,10 +1,11 @@
 import fs from "fs";
 import path from "path";
+import prettier from "prettier";
 
-processDir("packages");
-processDir("packages/adapters");
+await processDir("packages");
+await processDir("packages/adapters");
 
-function processDir(dir) {
+async function processDir(dir) {
   for (const name of fs.readdirSync(dir)) {
     const toggleFile = path.join(dir, name, "package.toggle.json");
     if (!fs.existsSync(toggleFile)) continue;
@@ -13,11 +14,19 @@ function processDir(dir) {
     const targetFile = path.join(dir, name, "package.json");
     const targetData = readJSON(targetFile);
     for (const key in toggleData) {
-      [targetData[key], toggleData[key]] = [toggleData[key], targetData[key]];
+      const value = toggleData[key];
+      // JSON has no `undefined`: a key the target lacks is kept as an
+      // explicit `null` marker so the next toggle deletes it off the target.
+      toggleData[key] = key in targetData ? targetData[key] : null;
+      if (value === null) {
+        delete targetData[key];
+      } else {
+        targetData[key] = value;
+      }
     }
 
-    writeJSON(targetFile, targetData);
-    writeJSON(toggleFile, toggleData);
+    await writeJSON(targetFile, targetData);
+    await writeJSON(toggleFile, toggleData);
   }
 }
 
@@ -25,6 +34,14 @@ function readJSON(filename) {
   return JSON.parse(fs.readFileSync(filename, "utf8"));
 }
 
-function writeJSON(filename, data) {
-  fs.writeFileSync(filename, `${JSON.stringify(data, null, 2)}\n`);
+async function writeJSON(filename, data) {
+  // Match the repository's committed formatting so toggling twice is a no-op
+  // (prettier keeps objects expanded when the input breaks their lines).
+  fs.writeFileSync(
+    filename,
+    await prettier.format(JSON.stringify(data, null, 2), {
+      ...(await prettier.resolveConfig(filename)),
+      filepath: filename,
+    }),
+  );
 }


### PR DESCRIPTION
## Description

Fixes `scripts/pkg-toggle.js` so keys present only in `package.toggle.json` (e.g. `typesVersions`) round-trip through an explicit `null` marker instead of being silently dropped, and formats its output with the repo's Prettier config so double-toggling is byte-stable. Also adds `formaction`, `formmethod`, and `taskkill` to `cspell.json` for words already used on `main`.

## Motivation and Context

On current `main`, `npm run lint` fails on a fresh clone and a release cycle loses toggle-only keys; both files are repo-internal tooling, so no changeset.

## Screenshots (if appropriate):

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2s4QxqWKA2NLuJoZGfWVG