### PR TITLE
fix(adapter-static): do not crawl `<a download>` or `rel="nofollow"` links

### DIFF
--- a/.changeset/crawler-download-attribute.md
+++ b/.changeset/crawler-download-attribute.md
@@ -1,0 +1,5 @@
+---
+"@marko/run-adapter-static": patch
+---
+
+Stop crawling `<a download>` links, and honor `rel="nofollow"` (plus `enclosure` and `external`) when it appears alongside other `rel` tokens. A bare `download` attribute parses as an empty string, so the check meant to skip those links only ever matched `download="filename"`, and `rel` was compared as a whole string rather than a token list. Links to files the app server does not serve were followed, and each one wrote the 404 page out under that path.

--- a/packages/adapters/static/src/crawler.ts
+++ b/packages/adapters/static/src/crawler.ts
@@ -166,7 +166,9 @@ export default function createCrawler(
 function getTagHref(tagName: string, attrs: Record<string, string>) {
   switch (tagName) {
     case "a":
-      if (attrs.href && !(attrs.download || ignoredRels.has(attrs.rel))) {
+      // `download` on its own parses to an empty string, so presence is what
+      // decides here: a truthiness check only ever skipped `download="name"`.
+      if (attrs.href && attrs.download == null && !hasIgnoredRel(attrs.rel)) {
         return attrs.href;
       }
       break;
@@ -196,6 +198,18 @@ function getTagHref(tagName: string, attrs: Record<string, string>) {
     case "iframe":
       return attrs.src;
   }
+}
+
+function hasIgnoredRel(rel: string | undefined) {
+  if (rel) {
+    for (const value of rel.split(/\s+/)) {
+      if (ignoredRels.has(value)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }
 
 function resolveUrl(href: string, origin: string) {


### PR DESCRIPTION
A bare `download` attribute parses as an empty string, so the truthiness check meant to skip `<a download>` links only ever matched `download="filename"`. Links pointing at files the app server does not serve were crawled, and each one wrote the 404 page out under that path.

The adjacent `rel` check had the same shape of bug: `rel` is a space-separated token list, but it was compared as a whole string, so `rel="nofollow noopener"` was crawled while bare `rel="nofollow"` was skipped. It now matches per token.