### PR TITLE
fix: declare the url parameter invoke already accepts

### DIFF
--- a/.changeset/invoke-url-param.md
+++ b/.changeset/invoke-url-param.md
@@ -1,0 +1,5 @@
+---
+"@marko/run": patch
+---
+
+Type the optional `url` argument `invoke` already accepts, so passing a rewritten URL no longer needs a cast.

--- a/packages/run/src/runtime/types.ts
+++ b/packages/run/src/runtime/types.ts
@@ -1050,6 +1050,7 @@ export type Invoke<TPlatform extends Platform = Platform> = (
   route: RouteMatch | null,
   request: Request,
   platform: TPlatform,
+  url?: URL,
 ) => Promise<Response | void>;
 export interface RuntimeModule {
   fetch<TPlatform extends Platform = Platform>(


### PR DESCRIPTION
Hey, @DylanPiercey. This one may take you some time; it's a hefty PR. Huge, even. Computationally intense.