### PR TITLE
fix(adapter-static): match `<link rel>` per token, not as a whole string

### DIFF
--- a/.changeset/crawler-link-rel-tokens.md
+++ b/.changeset/crawler-link-rel-tokens.md
@@ -1,0 +1,5 @@
+---
+"@marko/run-adapter-static": patch
+---
+
+Match `<link rel>` against each of its tokens when deciding what to crawl. `rel` is a space-separated token list, but it was compared as a whole string, so a page linked as `rel="alternate stylesheet"` fell through the allowlist and was left out of the static build.

--- a/packages/adapters/static/src/crawler.ts
+++ b/packages/adapters/static/src/crawler.ts
@@ -181,24 +181,28 @@ function getTagHref(tagName: string, attrs: Record<string, string>) {
       break;
     case "link":
       if (attrs.href) {
-        switch (attrs.rel) {
-          case "alternate":
-          case "author":
-          case "canonical":
-          case "help":
-          case "license":
-          case "next":
-          case "prefetch":
-          case "prerender":
-          case "prev":
-          case "search":
-          case "tag":
-            return attrs.href;
-          case "preload":
-            if (attrs.as === "document") {
+        // `rel` is a token list, so each token is matched on its own: a switch
+        // on the whole attribute misses `rel="alternate stylesheet"`.
+        for (const rel of relTokens(attrs.rel)) {
+          switch (rel) {
+            case "alternate":
+            case "author":
+            case "canonical":
+            case "help":
+            case "license":
+            case "next":
+            case "prefetch":
+            case "prerender":
+            case "prev":
+            case "search":
+            case "tag":
               return attrs.href;
-            }
-            break;
+            case "preload":
+              if (attrs.as === "document") {
+                return attrs.href;
+              }
+              break;
+          }
         }
       }
       break;
@@ -208,15 +212,17 @@ function getTagHref(tagName: string, attrs: Record<string, string>) {
 }
 
 function hasIgnoredRel(rel: string | undefined) {
-  if (rel) {
-    for (const value of rel.split(/\s+/)) {
-      if (ignoredRels.has(value)) {
-        return true;
-      }
+  for (const value of relTokens(rel)) {
+    if (ignoredRels.has(value)) {
+      return true;
     }
   }
 
   return false;
+}
+
+function relTokens(rel: string | undefined) {
+  return rel ? rel.split(/\s+/) : [];
 }
 
 /**


### PR DESCRIPTION
HTML defines `rel` as a space-separated token list, but the `link` branch of `getTagHref` switched on the whole attribute, so a page linked as `rel="alternate stylesheet"` fell through the allowlist and was left out of the static build.

Each token is now matched on its own. The splitting `hasIgnoredRel` already did for `<a rel>` in #225 is shared as `relTokens` and used by both.