### PR TITLE
fix: URL-decode catch-all route params

### DIFF
--- a/.changeset/proud-lions-decode.md
+++ b/.changeset/proud-lions-decode.md
@@ -1,0 +1,5 @@
+---
+"@marko/run": patch
+---
+
+URL-decode catch-all (`$$`) route params. Dynamic (`$`) segments were decoded but the catch-all was handed through raw, so the two param kinds disagreed and `Run.href`'s percent-encoding had no matching decode — `Run.href` for `["docs", "café"]` produced `/docs/caf%C3%A9`, and the linked page read back `params.rest === "docs/caf%C3%A9"`. The catch-all now decodes like every other param, completing the href round-trip. A request whose catch-all carries a malformed percent sequence now fails the same way it always has for dynamic segments.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -2,12 +2,6 @@
 
 Out-of-scope defects noticed while working on something else. Format and rules: [README.md](README.md).
 
-## URL-decode catch-all (`$$`) route params so they match dynamic (`$`) params and `Run.href` round-trips
-
-`packages/run/src/vite/codegen/index.ts` › `renderParams` | 2026-07-18 | impact:med | effort:low
-
-The generated router decodes dynamic `$` segments but not `$$` catch-alls, so the two param kinds disagree and `Run.href`'s encode has no matching decode. In `renderParams`, a dynamic segment is emitted as `s${index + 1}`, whose backing variable is materialized with `decodeURIComponent(...)` at `codegen/index.ts:595` and `:649`; the catch-all is emitted verbatim as `pathname.slice(${pathIndex})` at `codegen/index.ts:739` with no decode. Nothing downstream compensates: `createContext` (`packages/run/src/runtime/internal.ts:204-216`) hands `route.params` straight through. Meanwhile `Run.href` encodes every param including catch-alls (`href_path` maps `encodeURIComponent` over each array element, `packages/run/src/runtime/url-builder.ts:71`), so `Run.href("/$$rest", { params: { rest: ["docs", "café"] } })` produces `/docs/caf%C3%A9`, but the page it links to reads back `params.rest === "docs/caf%C3%A9"` instead of `"docs/café"` — a request for `/caf%C3%A9` hitting a sibling `$locale` correctly yields `"café"`. The encode half exists with no decode half, so the documented href↔route round-trip silently breaks for catch-alls only. Fix by decoding the catch-all, but per `/`-split segment rather than the whole string: a whole-string `decodeURIComponent` would turn an encoded `%2F` inside one captured segment into a real separator, whereas decoding each element (mirroring how `href_path` joins an array with raw `/` while encoding each element) keeps the two halves symmetric.
-
 ## Deleting a route file wedges the dev server: every SSR route then 500s with "Does the file exist?" and never self-heals
 
 `packages/run/src/vite/plugin.ts` › `load` | 2026-07-18 | impact:high | effort:med

--- a/packages/run/src/__tests__/fixtures/dynamic-rest/__snapshots__/dev.expected.md
+++ b/packages/run/src/__tests__/fixtures/dynamic-rest/__snapshots__/dev.expected.md
@@ -1,6 +1,6 @@
 # Loading
 
 ```html
-rest=foo/bar/baz
+rest=foo/café/baz
 ```
 

--- a/packages/run/src/__tests__/fixtures/dynamic-rest/__snapshots__/preview.expected.md
+++ b/packages/run/src/__tests__/fixtures/dynamic-rest/__snapshots__/preview.expected.md
@@ -1,6 +1,6 @@
 # Loading
 
 ```html
-rest=foo/bar/baz
+rest=foo/café/baz
 ```
 

--- a/packages/run/src/__tests__/fixtures/dynamic-rest/test.config.ts
+++ b/packages/run/src/__tests__/fixtures/dynamic-rest/test.config.ts
@@ -1,1 +1,3 @@
-export const path = '/foo/bar/baz'
+// The encoded segment must come back decoded: `Run.href` percent-encodes
+// every catch-all element, and the router owns the matching decode.
+export const path = "/foo/caf%C3%A9/baz";

--- a/packages/run/src/vite/__tests__/fixtures/build-routes/__snapshots__/build-routes.expected.router.js
+++ b/packages/run/src/vite/__tests__/fixtures/build-routes/__snapshots__/build-routes.expected.router.js
@@ -55,7 +55,7 @@ function match_internal(method, pathname) {
 					} break;
 				}
 			}
-			return { handler: get9, path: '/$$match', params: { match: pathname.slice(1) }, options: get9_options, meta: {} };
+			return { handler: get9, path: '/$$match', params: { match: decodeURIComponent(pathname.slice(1)) }, options: get9_options, meta: {} };
 		}
 		case 'HEAD':
 		case 'head': {
@@ -83,7 +83,7 @@ function match_internal(method, pathname) {
 					} break;
 				}
 			}
-			return { handler: head9, path: '/$$match', params: { match: pathname.slice(1) }, options: head9_options, meta: {} };
+			return { handler: head9, path: '/$$match', params: { match: decodeURIComponent(pathname.slice(1)) }, options: head9_options, meta: {} };
 		}
 		case 'POST':
 		case 'post': {

--- a/packages/run/src/vite/__tests__/fixtures/flat-routes/__snapshots__/flat-routes.expected.router.js
+++ b/packages/run/src/vite/__tests__/fixtures/flat-routes/__snapshots__/flat-routes.expected.router.js
@@ -48,7 +48,7 @@ function match_internal(method, pathname) {
 					} break;
 				}
 			}
-			return { handler: get4, path: '/$$rest', params: { rest: pathname.slice(1) }, options: get4_options, meta: {} };
+			return { handler: get4, path: '/$$rest', params: { rest: decodeURIComponent(pathname.slice(1)) }, options: get4_options, meta: {} };
 		}
 		case 'HEAD':
 		case 'head': {
@@ -80,7 +80,7 @@ function match_internal(method, pathname) {
 					} break;
 				}
 			}
-			return { handler: head4, path: '/$$rest', params: { rest: pathname.slice(1) }, options: head4_options, meta: {} };
+			return { handler: head4, path: '/$$rest', params: { rest: decodeURIComponent(pathname.slice(1)) }, options: head4_options, meta: {} };
 		}
 		case 'POST':
 		case 'post': {

--- a/packages/run/src/vite/__tests__/fixtures/optional-dynamic/__snapshots__/optional-dynamic.expected.router.js
+++ b/packages/run/src/vite/__tests__/fixtures/optional-dynamic/__snapshots__/optional-dynamic.expected.router.js
@@ -29,11 +29,11 @@ function match_internal(method, pathname) {
 							const s2 = decodeURIComponent(pathname.slice(i1, i2 ? -1 : len));
 							if (s2) return { handler: get1, path: '/$foo/$bar', params: { foo: s1, bar: s2 }, options: get1_options, meta: {} };
 						}
-						return { handler: get2, path: '/$foo/$$rest', params: { foo: s1, rest: pathname.slice(i1) }, options: get2_options, meta: {} };
+						return { handler: get2, path: '/$foo/$$rest', params: { foo: s1, rest: decodeURIComponent(pathname.slice(i1)) }, options: get2_options, meta: {} };
 					}
 				}
 			}
-			return { handler: get4, path: '/$$rest', params: { rest: pathname.slice(1) }, options: get4_options, meta: {} };
+			return { handler: get4, path: '/$$rest', params: { rest: decodeURIComponent(pathname.slice(1)) }, options: get4_options, meta: {} };
 		}
 		case 'HEAD':
 		case 'head': {
@@ -50,11 +50,11 @@ function match_internal(method, pathname) {
 							const s2 = decodeURIComponent(pathname.slice(i1, i2 ? -1 : len));
 							if (s2) return { handler: head1, path: '/$foo/$bar', params: { foo: s1, bar: s2 }, options: head1_options, meta: {} };
 						}
-						return { handler: head2, path: '/$foo/$$rest', params: { foo: s1, rest: pathname.slice(i1) }, options: head2_options, meta: {} };
+						return { handler: head2, path: '/$foo/$$rest', params: { foo: s1, rest: decodeURIComponent(pathname.slice(i1)) }, options: head2_options, meta: {} };
 					}
 				}
 			}
-			return { handler: head4, path: '/$$rest', params: { rest: pathname.slice(1) }, options: head4_options, meta: {} };
+			return { handler: head4, path: '/$$rest', params: { rest: decodeURIComponent(pathname.slice(1)) }, options: head4_options, meta: {} };
 		}
 	}
 	return null;

--- a/packages/run/src/vite/__tests__/fixtures/param-optional-rest/__snapshots__/param-optional-rest.expected.router.js
+++ b/packages/run/src/vite/__tests__/fixtures/param-optional-rest/__snapshots__/param-optional-rest.expected.router.js
@@ -22,7 +22,7 @@ function match_internal(method, pathname) {
 				} else {
 					const s1 = decodeURIComponent(pathname.slice(1, i1 - 1));
 					if (s1) {
-						return { handler: get2, path: '/$campaignId/$$rest', params: { campaignId: s1, rest: pathname.slice(i1) }, options: get2_options, meta: {} };
+						return { handler: get2, path: '/$campaignId/$$rest', params: { campaignId: s1, rest: decodeURIComponent(pathname.slice(i1)) }, options: get2_options, meta: {} };
 					}
 				}
 			}
@@ -38,7 +38,7 @@ function match_internal(method, pathname) {
 				} else {
 					const s1 = decodeURIComponent(pathname.slice(1, i1 - 1));
 					if (s1) {
-						return { handler: head2, path: '/$campaignId/$$rest', params: { campaignId: s1, rest: pathname.slice(i1) }, options: head2_options, meta: {} };
+						return { handler: head2, path: '/$campaignId/$$rest', params: { campaignId: s1, rest: decodeURIComponent(pathname.slice(i1)) }, options: head2_options, meta: {} };
 					}
 				}
 			}

--- a/packages/run/src/vite/codegen/index.ts
+++ b/packages/run/src/vite/codegen/index.ts
@@ -730,9 +730,13 @@ function renderParams(
   }
 
   if (catchAll) {
+    // Decoded like the `s${n}` vars backing dynamic segments, so the two
+    // param kinds agree and `Run.href`'s encode round-trips. Decoding the
+    // whole slice equals decoding per segment: a raw `/` can never sit
+    // inside a `%XX` triple.
     result += `${sep} ${wrapPropertyName(
       catchAll,
-    )}: pathname.slice(${pathIndex})`;
+    )}: decodeURIComponent(pathname.slice(${pathIndex}))`;
   }
 
   return result ? result + " }" : "{}";


### PR DESCRIPTION
## Description

The generated router decodes a dynamic `$` segment before it becomes a param — `renderParams` references the `s${n}` variable that was materialized with `decodeURIComponent(...)` — but a catch-all `$$` was emitted as raw `pathname.slice(i)`, and nothing downstream compensates. Meanwhile `Run.href` percent-encodes every param it interpolates, catch-all array elements included (`href_path` maps `encodeURIComponent` over each element and joins with `/`).

So the encode↔decode round-trip silently broke for catch-alls only:

```js
Run.href("/$$rest", { params: { rest: ["docs", "café"] } }); // "/docs/caf%C3%A9"
// ...and the page that link lands on:
$global.params.rest === "docs/caf%C3%A9"; // expected "docs/café"
```

The identical request hitting a sibling `$locale` route correctly yields `"café"` — the two param kinds disagreed.

### The fix

`renderParams` now emits `decodeURIComponent(pathname.slice(i))` for the catch-all, making it agree with the variables backing dynamic segments.

The recorded fix direction in `agent-feedback/bugs.md` prescribed decoding per `/`-split segment, on the grounds that a whole-string decode would turn an encoded `%2F` into a real separator where per-segment wouldn't. For a string-valued param the two forms are provably identical — `decodeURIComponent` distributes over `/` boundaries, since a raw `/` can never sit inside a `%XX` triple — in both value and throw behavior (verified across `%2F`, multi-byte, double-encoded, and malformed inputs). The segment-identity loss for an encoded `%2F` is inherent to the param being a string, and matches what `$` params already do with an encoded slash. So the simpler form is emitted.

**Behavior note:** a catch-all carrying a malformed percent sequence (e.g. `/docs/%`) now throws from the matcher exactly the way a dynamic segment always has, instead of passing the raw string through. The broader question of tolerating non-canonical encodings is a separate recorded entry and is not touched here.

## Motivation and Context

The documented href↔route round-trip produced encoded garbage for catch-all params only, with no workaround short of decoding in every handler. Resolves one entry in `agent-feedback/bugs.md`, which is removed here.

## Screenshots (if appropriate):

N/A

## Checklist:

- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

The four router-codegen snapshots with catch-alls regenerate with only the decode wrap (reviewed line by line, including the mixed `/$foo/$$rest` case where `foo: s1` was already decoded). The `dynamic-rest` e2e fixture now requests `/foo/caf%C3%A9/baz` and asserts `rest=foo/café/baz` in both dev and preview — with the fix reverted it fails showing exactly the recorded symptom (`rest=foo/caf%C3%A9/baz`). Full suite: 320 passing, 0 failing; lint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V888Mxok4otffCprmvyiKU)_