### PR TITLE
Serve dotted paths on the Netlify edge adapter

### DIFF
--- a/.changeset/netlify-edge-dotted-paths.md
+++ b/.changeset/netlify-edge-dotted-paths.md
@@ -1,0 +1,5 @@
+---
+"@marko/run-adapter-netlify": patch
+---
+
+Serve dotted URLs (e.g. `report.2024.pdf`, `jane.doe`, `.xml`/`.json` routes) on the edge adapter; previously any path containing a dot skipped the router and 404ed.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -2,12 +2,6 @@
 
 Out-of-scope defects noticed while working on something else. Format and rules: [README.md](README.md).
 
-## Serve dotted dynamic/catch-all paths on the Netlify edge adapter instead of dropping them via `pattern: "^[^.]*$"`
-
-`packages/adapters/netlify/src/default-edge-entry.ts` › `config` | 2026-07-19 | impact:high | effort:med
-
-The Netlify edge entry hardcodes `export const config = { pattern: "^[^.]*$" }` (`default-edge-entry.ts:12-14`). Netlify runs the edge function only when the request pathname matches this regex, and `^[^.]*$` matches only paths with zero dots, so any dotted URL never reaches the function; Netlify then serves it from the static publish dir and, with no matching asset, 404s. This silently drops every legitimate dynamic/catch-all route whose URL contains a dot: a `$$rest` catch-all serving `report.2024.pdf`, a `$handle` segment holding a username/slug/email (`jane.doe`), version params, or a handler emitting `.xml`/`.json`/`.txt`. The generated router matches those paths fine, and the same routes serve 200 in dev and on a workerd/Cloudflare build. The functions adapter gets this right with `{ path: "/*", preferStatic: true }` (`default-functions-entry.ts:4-6`), delegating static-vs-dynamic to Netlify's real file check instead of a path regex; the edge dot-heuristic was meant to skip asset paths but over-excludes all dotted paths, which also makes the `|| context.next()` fallback (`default-edge-entry.ts:8`) effectively dead for any app with routes. Fix: use Netlify's `excludedPath`/`excludedPattern` for real asset prefixes, or narrow the pattern to known static extensions, rather than a global dot exclusion. Undocumented: the Netlify section of `website/docs/marko-run/adapters.md` shows `edge: true` with no mention of the limitation. (@marko/run-adapter-netlify 3.0.6, @netlify/edge-functions 3.x.)
-
 ## Normalize `throw null` in the dev handler path so it cannot crash the dev server
 
 `packages/run/src/runtime/internal.ts` › `call` | 2026-07-18 | impact:high | effort:low

--- a/agent-feedback/cleanup.md
+++ b/agent-feedback/cleanup.md
@@ -2,6 +2,12 @@
 
 Duplication, dead code, inconsistencies, refactor opportunities. Format and rules: [README.md](README.md).
 
+## Wire the real `build.assetsDir` into the Netlify edge entry's `excludedPath`
+
+`packages/adapters/netlify/src/default-edge-entry.ts` › `config` | 2026-08-11 | impact:low | effort:med
+
+The edge entry's `excludedPath: ["/assets/*"]` hardcodes Vite's default `build.assetsDir`, so a project that overrides `assetsDir` invokes the edge function for every asset request; each still serves correctly via `context.next()`, it just loses the skip. The entry is a static file copied by `getEntryFile()`, so honoring the option means templating the entry at build time (or generating the config from the resolved Vite config) — plumbing that doesn't exist today.
+
 ## Build the crawler's initial queue from the deduped `seen` set, not the raw start-path array
 
 `packages/adapters/static/src/crawler.ts` › `crawl` | 2026-07-18 | impact:low | effort:low

--- a/packages/adapters/netlify/src/default-edge-entry.ts
+++ b/packages/adapters/netlify/src/default-edge-entry.ts
@@ -10,5 +10,8 @@ export default async function (request: Request, context: Context) {
 }
 
 export const config: Config = {
-  pattern: "^[^.]*$",
+  path: "/*",
+  // Skips Vite's default assets dir; a custom `build.assetsDir` still serves
+  // correctly via `context.next()`, it just doesn't get this shortcut.
+  excludedPath: ["/assets/*"],
 };


### PR DESCRIPTION
## Description

`@marko/run-adapter-netlify`: replace the edge entry's `pattern: "^[^.]*$"` with `path: "/*"` plus `excludedPath: ["/assets/*"]`, so all requests reach the router and unmatched paths fall through to static serving via the existing `context.next()`.

## Motivation and Context

The old regex only ran the edge function on paths with no dots, so any dotted URL (`report.2024.pdf` under a catch-all, a `jane.doe` param, `.xml`/`.json` handler routes) skipped the router and 404ed from the static publish dir. The `/assets/*` exclusion keeps hashed client bundles from invoking the function; a custom `build.assetsDir` still serves correctly, just without the shortcut (noted as a follow-up in `agent-feedback/cleanup.md`).

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
