### PR TITLE
fix: normalize nullish throws in the dev handler path

### DIFF
--- a/.changeset/throw-null-dev-server.md
+++ b/.changeset/throw-null-dev-server.md
@@ -1,0 +1,5 @@
+---
+"@marko/run": patch
+---
+
+`throw null` in a handler no longer crashes the dev server; it now skips handling the request in dev the same way it does in production.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -253,3 +253,9 @@ Dev runs Vite in middleware mode behind marko-run's own listener (`devServer.mid
 `packages/run/src/vite/plugin.ts` › `virtualFiles` | 2026-08-10 | impact:med | effort:med
 
 If `vite.config.ts` imports project source (e.g. to start a sidecar server from `configureServer`), editing any file in that import graph makes Vite restart in place — and after that restart every route answers 404 until the whole `marko-run dev` process is killed and restarted. Observed repeatedly in a real app; the workaround was spawning the sidecar as a child process (`spawn(process.execPath, [entry])`) so the config graph never touches server code, plus explicit `.ts` extensions to keep imports out of the graph. Suspect the `virtualFiles` map / route-walker state is not rebuilt on Vite's in-place restart path the way it is on first boot. Re-verify: a `marko-run dev` app whose `vite.config.ts` imports any file under `src/`; touch that file, wait for Vite's restart log, then curl any route — 404 until process restart.
+
+## Regenerate the `error-invalid-routes` dev snapshot for the appended agent fix guide
+
+`packages/run/src/__tests__/fixtures/error-invalid-routes/__snapshots__/dev.expected.md` › `error-invalid-routes` | 2026-08-11 | impact:med | effort:low
+
+`pnpm test` fails on `main` with one snapshot mismatch. `packages/run/src/vite/utils/agent-fix-guide.ts` › `appendAgentFixGuide` appends "Fix guide: READ <path>/cheatsheet.md before writing a fix." to route-conflict errors, but this fixture's committed snapshot predates that change and still holds the untagged message, so the rendered error page differs by those two lines. Re-verify: `pnpm test` on a clean `main`, "Duplicate routes for path /$" is the only failure. Fix with `pnpm run test:update` and review the diff for any other fixture that renders a tagged error.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -2,12 +2,6 @@
 
 Out-of-scope defects noticed while working on something else. Format and rules: [README.md](README.md).
 
-## Normalize `throw null` in the dev handler path so it cannot crash the dev server
-
-`packages/run/src/runtime/internal.ts` › `call` | 2026-07-18 | impact:high | effort:low
-
-The dev-mode warning in `call()` tells users to "finally `throw null` to skip handling the request", but only the production branch normalizes a nullish thrown value to `NotHandled` (line 355); the dev branch's catch (lines 330-335) rethrows raw `null`. The generated router only recognizes the `NotHandled`/`NotMatched` symbols (`packages/run/src/vite/codegen/index.ts:438`), so `null` reaches the node middleware's error handler, which reads `error.cause` on it (`packages/run/src/adapter/middleware.ts:182`) — the resulting `TypeError: Cannot read properties of null (reading 'cause')` escapes as an unhandled rejection and exits the whole process. Repro: `export const GET = Run.GET(() => { throw null; });` in any `+handler.js`, run `marko-run dev`, curl the route once — the server dies. Add the same `error == null → throw NotHandled` normalization to the dev branch, and consider a defensive null guard in middleware.ts.
-
 ## Fix the preview server's 302-to-/404 losing its Location header under compression
 
 `packages/adapters/static/src/index.ts` › `startPreview` | 2026-07-18 | impact:med | effort:low

--- a/packages/run/src/__tests__/adapter-middleware.test.ts
+++ b/packages/run/src/__tests__/adapter-middleware.test.ts
@@ -269,7 +269,7 @@ describe("Adapter Middleware", () => {
 
         const error = server.passedToNext;
         assert.ok(error instanceof Error);
-        assert.equal(error.message, "Handler threw a non-Error value");
+        assert.equal(error.message, "Unknown error handling request");
       } finally {
         await server.close();
       }

--- a/packages/run/src/__tests__/adapter-middleware.test.ts
+++ b/packages/run/src/__tests__/adapter-middleware.test.ts
@@ -47,6 +47,29 @@ async function serve(fetch: Fetch<any>) {
   };
 }
 
+async function serveWithNext(fetch: Fetch<any>) {
+  const handled = deferred();
+  let passedToNext: unknown;
+  const middleware = createMiddleware(fetch);
+  const server = http.createServer((req, res) => {
+    middleware(req, res, (err) => {
+      passedToNext = err;
+      res.statusCode = 500;
+      res.end("next");
+      handled.resolve();
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  return {
+    port: (server.address() as AddressInfo).port,
+    handled: handled.promise,
+    get passedToNext() {
+      return passedToNext;
+    },
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
 async function collect(reader: ReturnType<typeof getBodyReader>) {
   const decoder = new TextDecoder();
   let out = "";
@@ -227,6 +250,26 @@ describe("Adapter Middleware", () => {
 
         await closed.promise;
         assert.equal(signal.aborted, false);
+      } finally {
+        await server.close();
+      }
+    });
+
+    it("should pass a non-Error throw to next as an Error", async () => {
+      // A null-prototype object has no primitive conversion, so building the
+      // message out of the thrown value would throw inside the error path.
+      const server = await serveWithNext(async () => {
+        throw Object.create(null);
+      });
+
+      try {
+        const response = await fetch(`http://127.0.0.1:${server.port}/`);
+        assert.equal(await response.text(), "next");
+        await server.handled;
+
+        const error = server.passedToNext;
+        assert.ok(error instanceof Error);
+        assert.equal(error.message, "Handler threw a non-Error value");
       } finally {
         await server.close();
       }

--- a/packages/run/src/__tests__/call-return-value.test.ts
+++ b/packages/run/src/__tests__/call-return-value.test.ts
@@ -52,6 +52,17 @@ describe("call return value", () => {
     );
   });
 
+  it("should normalize a thrown nullish value to NotHandled", async () => {
+    await assert.rejects(
+      () => throwWith(null),
+      (error) => error === NotHandled,
+    );
+    await assert.rejects(
+      () => throwWith(undefined),
+      (error) => error === NotHandled,
+    );
+  });
+
   describe("in production", () => {
     withNodeEnv("production");
 
@@ -59,5 +70,22 @@ describe("call return value", () => {
       const items = { items: [] };
       assert.equal(await callWith(items), items as never);
     });
+
+    it("should normalize a thrown nullish value to NotHandled", async () => {
+      await assert.rejects(
+        () => throwWith(null),
+        (error) => error === NotHandled,
+      );
+    });
   });
 });
+
+function throwWith(thrown: unknown) {
+  return call(
+    (() => {
+      throw thrown;
+    }) as any,
+    next,
+    context,
+  );
+}

--- a/packages/run/src/__tests__/dev-hmr-port.test.ts
+++ b/packages/run/src/__tests__/dev-hmr-port.test.ts
@@ -30,7 +30,11 @@ describe("dev server hmr port", () => {
 
   beforeEach(() => {
     for (const name of ["a", "b"]) {
-      const root = fs.mkdtempSync(path.join(os.tmpdir(), `hmr-${name}-`));
+      // The real path keeps Windows 8.3 short names (RUNNER~1 on CI) out of
+      // the watched root, where they abort node in libuv's fs-event assert.
+      const root = fs.mkdtempSync(
+        path.join(fs.realpathSync.native(os.tmpdir()), `hmr-${name}-`),
+      );
       roots.push(root);
     }
   });

--- a/packages/run/src/adapter/middleware.ts
+++ b/packages/run/src/adapter/middleware.ts
@@ -218,7 +218,7 @@ export function createMiddleware(
       const error =
         err instanceof Error
           ? err
-          : new Error("Handler threw a non-Error value");
+          : new Error("Unknown error handling request");
 
       if (!process.env.NODE_ENV || process.env.NODE_ENV === "development") {
         if (error.cause && !error.message) {

--- a/packages/run/src/adapter/middleware.ts
+++ b/packages/run/src/adapter/middleware.ts
@@ -213,9 +213,12 @@ export function createMiddleware(
         return;
       }
 
-      // Nothing stops a handler from throwing a primitive; reading properties
-      // off it here would crash the process as an unhandled rejection.
-      const error = err instanceof Error ? err : new Error(String(err));
+      // A handler can throw a primitive; reading properties off it would crash
+      // the process, and converting it to text can throw again in this catch.
+      const error =
+        err instanceof Error
+          ? err
+          : new Error("Handler threw a non-Error value");
 
       if (!process.env.NODE_ENV || process.env.NODE_ENV === "development") {
         if (error.cause && !error.message) {

--- a/packages/run/src/adapter/middleware.ts
+++ b/packages/run/src/adapter/middleware.ts
@@ -213,7 +213,9 @@ export function createMiddleware(
         return;
       }
 
-      const error = err as Error;
+      // Nothing stops a handler from throwing a primitive; reading properties
+      // off it here would crash the process as an unhandled rejection.
+      const error = err instanceof Error ? err : new Error(String(err));
 
       if (!process.env.NODE_ENV || process.env.NODE_ENV === "development") {
         if (error.cause && !error.message) {

--- a/packages/run/src/runtime/internal.ts
+++ b/packages/run/src/runtime/internal.ts
@@ -270,7 +270,9 @@ export async function call(
       }) as NextFunction);
     } catch (error) {
       didThrow = true;
-      if (error instanceof Response) {
+      if (error == null) {
+        throw NotHandled;
+      } else if (error instanceof Response) {
         return error;
       }
       throw error;


### PR DESCRIPTION
## Description

`@marko/run`: the dev branch of `call()` now normalizes a thrown nullish value to `NotHandled`, matching the production branch. The node adapter middleware's catch also wraps non-`Error` thrown values before reading `.cause`/`.message` off them.

## Motivation and Context

The dev warning tells users to `throw null` to skip handling a request, but only production honored it — in dev the raw `null` reached the middleware error handler, whose `error.cause` read threw inside the catch and killed the whole dev server as an unhandled rejection. One `throw null` plus one request took the server down.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
