### PR TITLE
fix: shut down the spawned preview server on CLI exit

### DIFF
--- a/.changeset/preview-close-on-exit.md
+++ b/.changeset/preview-close-on-exit.md
@@ -1,0 +1,5 @@
+---
+"@marko/run": patch
+---
+
+Ctrl+C on `marko-run preview` now shuts down the spawned server; previously it survived the CLI and kept its port.

--- a/.changeset/preview-close-on-exit.md
+++ b/.changeset/preview-close-on-exit.md
@@ -2,4 +2,4 @@
 "@marko/run": patch
 ---
 
-Ctrl+C on `marko-run preview` now shuts down the spawned server; previously it survived the CLI and kept its port.
+The servers spawned by `marko-run preview` and `marko-run dev` now shut down when the CLI receives SIGINT or SIGTERM; previously they survived the CLI and kept their port.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -2,12 +2,6 @@
 
 Out-of-scope defects noticed while working on something else. Format and rules: [README.md](README.md).
 
-## Clean up the spawned preview server on CLI exit — Ctrl+C orphans it and it keeps the port
-
-`packages/run/src/vite/utils/server.ts` › `spawnServer` | 2026-07-18 | impact:med | effort:med
-
-`spawnServer` launches the built server `detached` (its own process group) on posix, and the CLI (packages/run/src/cli/index.ts) installs no SIGINT/SIGTERM/exit handling and never calls the returned `close()`. Sending SIGINT to `marko-run preview` terminates the CLI, but the detached `node dist/index.mjs` child survives indefinitely and keeps serving its port; a terminal Ctrl+C behaves the same because the child's process group never receives the signal. Combined with the silent busy-port fallback in `getAvailablePort`, every restart then binds a new ephemeral port while orphaned servers accumulate. Trap signals in the CLI and invoke the existing `closeSpawnedProcess`/`killTree` cleanup, or stop detaching the child on posix.
-
 ## Move dev's generated route entries out of the build outDir so `marko-run build` can't break a running dev server
 
 `packages/run/src/vite/plugin.ts` › `config` | 2026-07-18 | impact:med | effort:med

--- a/packages/run/src/cli/commands.ts
+++ b/packages/run/src/cli/commands.ts
@@ -14,7 +14,11 @@ import {
 } from "../vite/plugin";
 import type { StartDevOptions, StartPreviewOptions } from "../vite/types";
 import { setExternalAdapterOptions } from "../vite/utils/config";
-import { getAvailablePort, type SpawnedServer } from "../vite/utils/server";
+import {
+  closeOnExit,
+  getAvailablePort,
+  type SpawnedServer,
+} from "../vite/utils/server";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -79,10 +83,12 @@ export async function preview(
     entry,
   };
 
-  return await adapter.startPreview({
-    entry: entryFile,
-    options,
-  });
+  return closeOnExit(
+    await adapter.startPreview({
+      entry: entryFile,
+      options,
+    }),
+  );
 }
 
 export async function dev(
@@ -149,7 +155,7 @@ export async function dev(
     envFile,
   };
 
-  return await adapter.startDev({ entry, config, options });
+  return closeOnExit(await adapter.startDev({ entry, config, options }));
 }
 
 export async function build(

--- a/packages/run/src/vite/utils/server.ts
+++ b/packages/run/src/vite/utils/server.ts
@@ -18,16 +18,22 @@ export interface SpawnedServer {
  * server unregisters the handlers.
  */
 export function closeOnExit(server: SpawnedServer): SpawnedServer {
+  let closing: Promise<void> | undefined;
   const onSignal = async () => {
-    await wrapped.close();
-    process.exit();
+    try {
+      await wrapped.close();
+    } finally {
+      process.exit();
+    }
   };
   const wrapped: SpawnedServer = {
     port: server.port,
-    async close() {
-      process.off("SIGINT", onSignal);
-      process.off("SIGTERM", onSignal);
-      await server.close();
+    close() {
+      return (closing ??= (async () => {
+        process.off("SIGINT", onSignal);
+        process.off("SIGTERM", onSignal);
+        await server.close();
+      })());
     },
   };
   process.once("SIGINT", onSignal);

--- a/packages/run/src/vite/utils/server.ts
+++ b/packages/run/src/vite/utils/server.ts
@@ -10,6 +10,31 @@ export interface SpawnedServer {
   close(): Promise<void> | void;
 }
 
+/**
+ * Closes the server before exiting on SIGINT/SIGTERM. The spawned server is
+ * detached into its own process group on posix so its whole tree can be
+ * killed, which also means a terminal Ctrl+C never reaches it — without this
+ * it outlives its parent and keeps its port. Calling `close` on the returned
+ * server unregisters the handlers.
+ */
+export function closeOnExit(server: SpawnedServer): SpawnedServer {
+  const onSignal = async () => {
+    await wrapped.close();
+    process.exit();
+  };
+  const wrapped: SpawnedServer = {
+    port: server.port,
+    async close() {
+      process.off("SIGINT", onSignal);
+      process.off("SIGTERM", onSignal);
+      await server.close();
+    },
+  };
+  process.once("SIGINT", onSignal);
+  process.once("SIGTERM", onSignal);
+  return wrapped;
+}
+
 export async function parseEnv(envFile: string) {
   if (fs.existsSync(envFile)) {
     const content = await fs.promises.readFile(envFile, "utf8");


### PR DESCRIPTION
## Description

`@marko/run`: add a `closeOnExit` wrapper in `vite/utils/server.ts` that closes a spawned server on SIGINT/SIGTERM before exiting, applied where the `preview` and `dev` commands create their servers so every caller gets the behavior. Closing the server unregisters the handlers.

## Motivation and Context

`spawnServer` detaches the built server into its own process group on posix (so its whole tree can be killed), which also means a terminal Ctrl+C never reaches it. With no signal handling, the child survived the CLI indefinitely and kept its port, and each restart silently bound a new ephemeral port while orphans accumulated. Verified: SIGINT to `marko-run preview` now exits the CLI and frees the port.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
