### PR TITLE
chore: move the pre-stream render-error item to cleanup as a revisit note

### DIFF
--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -2,12 +2,6 @@
 
 Out-of-scope defects noticed while working on something else. Format and rules: [README.md](README.md).
 
-## Catch page-render stream errors so +500.marko applies and stacks don't reach clients
-
-`packages/run/src/vite/codegen/index.ts` › `renderRouter` | 2026-07-18 | impact:high | effort:med
-
-The generated `invoke` only try/catches `await route.handler(context)` (with the outer catch at codegen/index.ts:476 rendering page500), but `context.render` (packages/run/src/runtime/internal.ts:241) returns a Response whose body is a lazily-produced Marko stream, so an error thrown while rendering the page — e.g. a `+page.marko` containing `<const/x=(() => { throw new Error("boom") })()>` — escapes that catch entirely. The node adapter middleware then hits the error while iterating `response.body` (packages/run/src/adapter/middleware.ts:165) and calls `next(error)`, so under an Express custom entry with `NODE_ENV` unset (plain `node dist/index.mjs`) the client receives Express's default error page with the full stack trace and absolute server paths; with `NODE_ENV=production` the stack is hidden but +500.marko is still never rendered — only middleware/handler-phase errors reach it. Repro: build, run, `curl -H 'accept: text/html' /boom`. Consider catching errors from the render stream and, when no bytes have flushed, substituting the page500 render (or at minimum a generic 500 body) instead of propagating to the host framework's error handler.
-
 ## Return 400/413 instead of 500 for malformed or oversized request bodies
 
 `packages/run/src/runtime/internal.ts` › `readBody` | 2026-07-18 | impact:med | effort:low

--- a/agent-feedback/cleanup.md
+++ b/agent-feedback/cleanup.md
@@ -2,6 +2,12 @@
 
 Duplication, dead code, inconsistencies, refactor opportunities. Format and rules: [README.md](README.md).
 
+## Revisit: surface pre-stream page-render errors to the +500 page
+
+`packages/run/src/runtime/internal.ts` › `createContext.render` | 2026-08-11 | impact:med | effort:med
+
+An error thrown during a page's synchronous render pass escapes the generated `invoke`'s try/catch because the response body is lazy; the node middleware hits it mid-iteration and hands it to the host framework, so an Express custom entry serves its default error page (stack trace included with `NODE_ENV` unset) and `+500.marko` never renders. A working approach was prototyped and shelved in PR #255: make `context.render` async, eagerly pull/replay the sync render pass (bounded by one macrotask), and await it so the rejection reaches `invoke`'s existing catch — mid-stream errors stay the territory of `<try>`/`<@catch>`. Notes from that spike: the client-entry `<script>` preamble flushes as a chunk before the page body, so a one-chunk peek is not enough; and a `<const/x=(() => { throw })()>` never surfaces its error to the stream at all (separate marko behavior — repro with a throw in a rendered expression instead).
+
 ## Wire the real `build.assetsDir` into the Netlify edge entry's `excludedPath`
 
 `packages/adapters/netlify/src/default-edge-entry.ts` › `config` | 2026-08-11 | impact:low | effort:med


### PR DESCRIPTION
## Description

Moves the "catch page-render stream errors so +500.marko applies" item from `agent-feedback/bugs.md` to `agent-feedback/cleanup.md` as a revisit entry, preserving the findings from the shelved prototype (PR #255).

## Motivation and Context

Triage decided not to land the fix now; the note keeps the diagnosis and the prototyped approach from being lost or re-reported.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
