### PR TITLE
fix: respond 400/413 for malformed or oversized request bodies

### DIFF
--- a/.changeset/body-4xx-statuses.md
+++ b/.changeset/body-4xx-statuses.md
@@ -1,0 +1,5 @@
+---
+"@marko/run": patch
+---
+
+Malformed request bodies (invalid JSON, bad encoding, unparsable multipart) now respond 400 and bodies exceeding the configured size limits respond 413, instead of surfacing as server 500s.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -2,12 +2,6 @@
 
 Out-of-scope defects noticed while working on something else. Format and rules: [README.md](README.md).
 
-## Return 400/413 instead of 500 for malformed or oversized request bodies
-
-`packages/run/src/runtime/internal.ts` › `readBody` | 2026-07-18 | impact:med | effort:low
-
-When a route configures the `json` body option, `readBody` does a bare `JSON.parse` (internal.ts:153) on the request body, and `readBodyWithLimit` throws a plain `Error("Request body too large")` (internal.ts:112 and :130); both propagate as uncaught server errors, so a client sending `{oops` or an over-limit body gets a 500 (and the +500 HTML page when Accept includes text/html) rather than 400/413. Repro: `curl -X POST -H 'content-type: application/json' -d '{oops' /any-json-route` returns HTTP 500 in both dev and production builds. Client-input errors surfacing as server faults also pollute error monitoring, and packages/run/README.md:572 only says oversized requests "are rejected". Since thrown `Response` objects are already honored (internal.ts:332 and :357 — a validator throwing `Response.json(..., { status: 400 })` works today), throwing `Response` instances with status 400/413 from `readBody`/`readBodyWithLimit` would fix this cleanly.
-
 ## Reject unconfigured content-types in readBody instead of falling back to form parsing
 
 `packages/run/src/runtime/internal.ts` › `readBody` | 2026-07-18 | impact:med | effort:med

--- a/agent-feedback/dx.md
+++ b/agent-feedback/dx.md
@@ -203,3 +203,9 @@ The root `lint` script is `eslint --format unix . && prettier . --check --log-le
 `AGENTS.md` › `## Conventions` | 2026-08-07 | impact:low | effort:low
 
 CodeRabbit's pre-merge checks (configured in the organization UI; the repo has no `.coderabbit.yaml`) require 80% docstring coverage and flagged PR #243 at 13.33% with "Write docstrings for the functions missing them", while `AGENTS.md` treats comments as a last resort and only guarantees JSDoc where it earns its place — so the two policies will disagree on nearly every code PR, and following the bot's resolution would violate the repo's own conventions. Lower or disable the docstring-coverage threshold in the CodeRabbit organization settings, or add a repo `.coderabbit.yaml` that overrides it, so reviews stop prompting for docstrings the conventions reject.
+
+## Add "macrotask" to the cspell dictionary so `pnpm run lint` passes on main
+
+`cspell.json` › `words` | 2026-08-11 | impact:med | effort:low
+
+`pnpm run lint` fails on a clean `main` with a single cspell error: `agent-feedback/cleanup.md` uses "macrotask", which is not in `cspell.json`'s `words` list. The word arrived with 445114c (#256) and the check covers `**/*.{md,ts,marko}`, so every branch cut from main inherits a red lint until the word is added. Re-verify: `npx cspell "**/*.{md,ts,marko}" --no-progress` on main reports one issue.

--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -569,7 +569,7 @@ export const POST = Run.POST(
 - `json` handles `application/json` requests. It can be a validator, or an options object `{ validator?, maxBytes? }`.
 - `form` handles `application/x-www-form-urlencoded` and `multipart/form-data` requests. It can be a validator, or an options object `{ validator?, maxBytes?, maxParts?, maxFiles?, maxFileBytes?, onFile? }`. Repeated fields become arrays, and `onFile(context, file)` is called for each uploaded file in multipart requests.
 - Function validators resolve `context.body` to their return value; Standard Schema validators resolve it to a `[value, issues]` tuple; with no validator it resolves to the raw parsed body.
-- Requests exceeding the configured size limits are rejected.
+- Requests exceeding the configured size limits are rejected with a `413` response; malformed bodies (invalid JSON, invalid encoding, unparsable multipart) are rejected with a `400`.
 
 ### Loading Data
 

--- a/packages/run/src/__tests__/fixtures/request-body-json/__snapshots__/dev.expected.md
+++ b/packages/run/src/__tests__/fixtures/request-body-json/__snapshots__/dev.expected.md
@@ -7,3 +7,9 @@ Page Rendered
 # Step 0
 page
 
+# Step 1
+page
+
+# Step 2
+page
+

--- a/packages/run/src/__tests__/fixtures/request-body-json/__snapshots__/dev.expected.md
+++ b/packages/run/src/__tests__/fixtures/request-body-json/__snapshots__/dev.expected.md
@@ -13,3 +13,6 @@ page
 # Step 2
 page
 
+# Step 3
+page
+

--- a/packages/run/src/__tests__/fixtures/request-body-json/__snapshots__/preview.expected.md
+++ b/packages/run/src/__tests__/fixtures/request-body-json/__snapshots__/preview.expected.md
@@ -7,3 +7,9 @@ Page Rendered
 # Step 0
 page
 
+# Step 1
+page
+
+# Step 2
+page
+

--- a/packages/run/src/__tests__/fixtures/request-body-json/__snapshots__/preview.expected.md
+++ b/packages/run/src/__tests__/fixtures/request-body-json/__snapshots__/preview.expected.md
@@ -13,3 +13,6 @@ page
 # Step 2
 page
 
+# Step 3
+page
+

--- a/packages/run/src/__tests__/fixtures/request-body-json/src/routes/+handler.ts
+++ b/packages/run/src/__tests__/fixtures/request-body-json/src/routes/+handler.ts
@@ -2,10 +2,13 @@ import * as v from "valibot";
 
 export const POST = Run.POST(
   {
-    json: v.object({
-      name: v.string(),
-      age: v.number()
-    }),
+    json: {
+      validator: v.object({
+        name: v.string(),
+        age: v.number()
+      }),
+      maxBytes: 256,
+    },
   },
   async (ctx) => {
     await ctx.body; // verify body can be accessed multiple times

--- a/packages/run/src/__tests__/fixtures/request-body-json/test.config.ts
+++ b/packages/run/src/__tests__/fixtures/request-body-json/test.config.ts
@@ -2,7 +2,12 @@ import assert from "assert";
 
 import { Step, StepContext } from "../../main.test";
 
-export const steps: Step[] = [post, postMalformed, postTooLarge];
+export const steps: Step[] = [
+  post,
+  postMalformed,
+  postTooLarge,
+  postBadEncoding,
+];
 
 async function postMalformed({ page }: StepContext) {
   const response = await page.fetch(page.url(), {
@@ -11,6 +16,7 @@ async function postMalformed({ page }: StepContext) {
     body: "{oops",
   });
   assert.equal(response.status, 400);
+  assert.equal(await response.text(), "");
 }
 
 async function postTooLarge({ page }: StepContext) {
@@ -20,6 +26,17 @@ async function postTooLarge({ page }: StepContext) {
     body: JSON.stringify({ name: "x".repeat(300), age: 7 }),
   });
   assert.equal(response.status, 413);
+  assert.equal(await response.text(), "");
+}
+
+async function postBadEncoding({ page }: StepContext) {
+  const response = await page.fetch(page.url(), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    // `"x` followed by an invalid UTF-8 sequence.
+    body: new Uint8Array([0x22, 0x78, 0xc3, 0x28]),
+  });
+  assert.equal(response.status, 400);
 }
 
 async function post({ page }: StepContext) {

--- a/packages/run/src/__tests__/fixtures/request-body-json/test.config.ts
+++ b/packages/run/src/__tests__/fixtures/request-body-json/test.config.ts
@@ -2,7 +2,25 @@ import assert from "assert";
 
 import { Step, StepContext } from "../../main.test";
 
-export const steps: Step[] = [post];
+export const steps: Step[] = [post, postMalformed, postTooLarge];
+
+async function postMalformed({ page }: StepContext) {
+  const response = await page.fetch(page.url(), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: "{oops",
+  });
+  assert.equal(response.status, 400);
+}
+
+async function postTooLarge({ page }: StepContext) {
+  const response = await page.fetch(page.url(), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ name: "x".repeat(300), age: 7 }),
+  });
+  assert.equal(response.status, 413);
+}
 
 async function post({ page }: StepContext) {
   const response = await page.fetch(page.url(), {

--- a/packages/run/src/runtime/internal.ts
+++ b/packages/run/src/runtime/internal.ts
@@ -74,10 +74,8 @@ type Rendered = ReturnType<Marko.Template["render"]> & AsyncIterable<string>;
 // `adapter/middleware`, which is bundled separately.
 const kRender = Symbol.for("@marko/run.render");
 
-// Marks an error as a client fault: `call()` answers with a bare response of
-// this status instead of letting it surface as a server error. Kept on plain
-// `Error`s so an author's try/catch around `await context.body` sees a normal
-// error rather than a thrown `Response`.
+// Marks an error as a client fault; `call()` answers with a bare response of
+// this status instead of letting it surface as a server error.
 const kErrorStatus = Symbol.for("@marko/run.errorStatus");
 
 let toReadable = (rendered: Rendered): ReadableStream<Uint8Array> => {
@@ -289,9 +287,7 @@ export async function call(
       } else if (error instanceof Response) {
         return error;
       } else if (typeof error === "object" && kErrorStatus in error) {
-        return new Response((error as unknown as Error).message, {
-          status: (error as any)[kErrorStatus],
-        });
+        return new Response(null, { status: (error as any)[kErrorStatus] });
       }
       throw error;
     } finally {
@@ -332,9 +328,7 @@ export async function call(
       } else if (error instanceof Response) {
         return error;
       } else if (typeof error === "object" && kErrorStatus in error) {
-        return new Response((error as unknown as Error).message, {
-          status: (error as any)[kErrorStatus],
-        });
+        return new Response(null, { status: (error as any)[kErrorStatus] });
       }
       throw error;
     }
@@ -582,57 +576,60 @@ function searchParamsToObject(params: URLSearchParams | FormData) {
 
 // Failures here are the client's fault, so they throw status-stamped errors
 // (see `kErrorStatus`) instead of surfacing as server errors.
+// Fatal decode, so malformed UTF-8 is a client error rather than U+FFFD noise.
+const bodyDecoder = new TextDecoder("utf-8", { fatal: true });
+
 async function readBodyWithLimit(request: Request, maxBytes: number) {
+  let bytes: ArrayBuffer | Uint8Array;
+
   if (maxBytes < 0) {
-    return await request.text();
-  }
+    bytes = await request.arrayBuffer();
+  } else {
+    const contentLength = request.headers.get("content-length");
 
-  const contentLength = request.headers.get("content-length");
-
-  if (contentLength !== null && Number(contentLength) > maxBytes) {
-    throw bodyTooLarge();
-  }
-
-  if (!request.body) {
-    throw clientError("Missing request body", 400);
-  }
-
-  const reader = request.body.getReader();
-  const bytes = new Uint8Array(maxBytes);
-  let receivedBytes = 0;
-
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-
-      if (receivedBytes + value.byteLength > maxBytes) {
-        await reader.cancel();
-        throw bodyTooLarge();
-      }
-
-      bytes.set(value, receivedBytes);
-      receivedBytes += value.byteLength;
+    if (contentLength !== null && Number(contentLength) > maxBytes) {
+      throw clientError("Request body too large", 413);
     }
-  } finally {
-    reader.releaseLock();
+
+    if (!request.body) {
+      throw clientError("Missing request body", 400);
+    }
+
+    const reader = request.body.getReader();
+    const buffer = new Uint8Array(maxBytes);
+    let receivedBytes = 0;
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        if (receivedBytes + value.byteLength > maxBytes) {
+          await reader.cancel();
+          throw clientError("Request body too large", 413);
+        }
+
+        buffer.set(value, receivedBytes);
+        receivedBytes += value.byteLength;
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    bytes = buffer.subarray(0, receivedBytes);
   }
 
   try {
-    return new TextDecoder("utf-8", { fatal: true }).decode(
-      bytes.subarray(0, receivedBytes),
-    );
+    return bodyDecoder.decode(bytes);
   } catch (error) {
     throw clientError("Invalid request body encoding", 400, error);
   }
 }
 
-function bodyTooLarge() {
-  return clientError("Request body too large", 413);
-}
-
-function clientError(message: string, status: number, cause?: unknown) {
-  const error = new Error(message, cause === undefined ? undefined : { cause });
+// Stamps the thrown error itself when there is one, keeping its message and
+// stack; `message` describes the failure for everything else.
+function clientError(message: string, status: number, thrown?: unknown) {
+  const error = thrown instanceof Error ? thrown : new Error(message);
   (error as any)[kErrorStatus] = status;
   return error;
 }
@@ -644,10 +641,7 @@ async function readBody(route: RouteMatch, context: Context) {
     const { maxBytes = defaultMaxBytes, validator } = route.options.json ?? {};
     let json;
     try {
-      json =
-        maxBytes < 0
-          ? await request.json()
-          : JSON.parse(await readBodyWithLimit(request, maxBytes));
+      json = JSON.parse(await readBodyWithLimit(request, maxBytes));
     } catch (error) {
       if (typeof error === "object" && error && kErrorStatus in error)
         throw error;
@@ -686,7 +680,7 @@ async function readBody(route: RouteMatch, context: Context) {
       error instanceof MaxPartsExceededError ||
       error instanceof MaxTotalSizeExceededError
     ) {
-      throw bodyTooLarge();
+      throw clientError("Request body too large", 413, error);
     }
     if (
       error instanceof FormDataParseError ||

--- a/packages/run/src/runtime/internal.ts
+++ b/packages/run/src/runtime/internal.ts
@@ -1,6 +1,14 @@
 /// <reference types="marko" />
 
-import { parseFormData } from "@remix-run/form-data-parser";
+import {
+  FormDataParseError,
+  MaxFilesExceededError,
+  MaxFileSizeExceededError,
+  MaxPartsExceededError,
+  MaxTotalSizeExceededError,
+  MultipartParseError,
+  parseFormData,
+} from "@remix-run/form-data-parser";
 
 import { httpVerbs } from "../vite/constants";
 import type {
@@ -65,6 +73,12 @@ type Rendered = ReturnType<Marko.Template["render"]> & AsyncIterable<string>;
 // Registry key for the raw render carried on a page `Response`; also read by
 // `adapter/middleware`, which is bundled separately.
 const kRender = Symbol.for("@marko/run.render");
+
+// Marks an error as a client fault: `call()` answers with a bare response of
+// this status instead of letting it surface as a server error. Kept on plain
+// `Error`s so an author's try/catch around `await context.body` sees a normal
+// error rather than a thrown `Response`.
+const kErrorStatus = Symbol.for("@marko/run.errorStatus");
 
 let toReadable = (rendered: Rendered): ReadableStream<Uint8Array> => {
   toReadable = (rendered as any).toReadable
@@ -274,6 +288,10 @@ export async function call(
         throw NotHandled;
       } else if (error instanceof Response) {
         return error;
+      } else if (typeof error === "object" && kErrorStatus in error) {
+        return new Response((error as unknown as Error).message, {
+          status: (error as any)[kErrorStatus],
+        });
       }
       throw error;
     } finally {
@@ -313,6 +331,10 @@ export async function call(
         throw NotHandled;
       } else if (error instanceof Response) {
         return error;
+      } else if (typeof error === "object" && kErrorStatus in error) {
+        return new Response((error as unknown as Error).message, {
+          status: (error as any)[kErrorStatus],
+        });
       }
       throw error;
     }
@@ -558,6 +580,8 @@ function searchParamsToObject(params: URLSearchParams | FormData) {
   return obj;
 }
 
+// Failures here are the client's fault, so they throw status-stamped errors
+// (see `kErrorStatus`) instead of surfacing as server errors.
 async function readBodyWithLimit(request: Request, maxBytes: number) {
   if (maxBytes < 0) {
     return await request.text();
@@ -566,11 +590,11 @@ async function readBodyWithLimit(request: Request, maxBytes: number) {
   const contentLength = request.headers.get("content-length");
 
   if (contentLength !== null && Number(contentLength) > maxBytes) {
-    throw new Error("Request body too large");
+    throw bodyTooLarge();
   }
 
   if (!request.body) {
-    throw new Error("Missing request body");
+    throw clientError("Missing request body", 400);
   }
 
   const reader = request.body.getReader();
@@ -584,7 +608,7 @@ async function readBodyWithLimit(request: Request, maxBytes: number) {
 
       if (receivedBytes + value.byteLength > maxBytes) {
         await reader.cancel();
-        throw new Error("Request body too large");
+        throw bodyTooLarge();
       }
 
       bytes.set(value, receivedBytes);
@@ -594,9 +618,23 @@ async function readBodyWithLimit(request: Request, maxBytes: number) {
     reader.releaseLock();
   }
 
-  return new TextDecoder("utf-8", { fatal: true }).decode(
-    bytes.subarray(0, receivedBytes),
-  );
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(
+      bytes.subarray(0, receivedBytes),
+    );
+  } catch (error) {
+    throw clientError("Invalid request body encoding", 400, error);
+  }
+}
+
+function bodyTooLarge() {
+  return clientError("Request body too large", 413);
+}
+
+function clientError(message: string, status: number, cause?: unknown) {
+  const error = new Error(message, cause === undefined ? undefined : { cause });
+  (error as any)[kErrorStatus] = status;
+  return error;
 }
 
 async function readBody(route: RouteMatch, context: Context) {
@@ -604,10 +642,17 @@ async function readBody(route: RouteMatch, context: Context) {
   const contentType = request.headers.get("Content-Type");
   if (contentType?.includes("application/json")) {
     const { maxBytes = defaultMaxBytes, validator } = route.options.json ?? {};
-    const json =
-      maxBytes < 0
-        ? await request.json()
-        : JSON.parse(await readBodyWithLimit(request, maxBytes));
+    let json;
+    try {
+      json =
+        maxBytes < 0
+          ? await request.json()
+          : JSON.parse(await readBodyWithLimit(request, maxBytes));
+    } catch (error) {
+      if (typeof error === "object" && error && kErrorStatus in error)
+        throw error;
+      throw clientError("Invalid JSON body", 400, error);
+    }
     return validator ? validator(json) : json;
   }
   const {
@@ -618,20 +663,41 @@ async function readBody(route: RouteMatch, context: Context) {
     onFile,
     validator,
   } = route.options.form ?? {};
-  const data = searchParamsToObject(
-    contentType?.includes("multipart/form-data")
-      ? await parseFormData(
-          request,
-          {
-            maxParts,
-            maxFiles,
-            maxFileSize: maxFileBytes,
-            maxTotalSize: maxBytes,
-          },
-          onFile ? (file) => onFile!(context, file) : undefined,
-        )
-      : new URLSearchParams(await readBodyWithLimit(request, maxBytes)),
-  );
+  let data;
+  try {
+    data = searchParamsToObject(
+      contentType?.includes("multipart/form-data")
+        ? await parseFormData(
+            request,
+            {
+              maxParts,
+              maxFiles,
+              maxFileSize: maxFileBytes,
+              maxTotalSize: maxBytes,
+            },
+            onFile ? (file) => onFile!(context, file) : undefined,
+          )
+        : new URLSearchParams(await readBodyWithLimit(request, maxBytes)),
+    );
+  } catch (error) {
+    if (
+      error instanceof MaxFilesExceededError ||
+      error instanceof MaxFileSizeExceededError ||
+      error instanceof MaxPartsExceededError ||
+      error instanceof MaxTotalSizeExceededError
+    ) {
+      throw bodyTooLarge();
+    }
+    if (
+      error instanceof FormDataParseError ||
+      error instanceof MultipartParseError
+    ) {
+      throw clientError("Invalid form body", 400, error);
+    }
+    // Anything else — an `onFile` handler failure, a thrown `Response` — is
+    // not a malformed-body case and keeps its meaning.
+    throw error;
+  }
   return validator ? validator(data) : data;
 }
 


### PR DESCRIPTION
## Description

`@marko/run`: body-read failures now throw plain `Error`s stamped with a `kErrorStatus` symbol carrying the intended status; `call()` recognizes the stamp and answers with a bare response of that status (413 for bodies over the configured limits, including multipart file/part/total limits; 400 for invalid JSON, invalid UTF-8, unparsable multipart, and a missing body). An `onFile` handler failure or any other unexpected error keeps its meaning as a server error.

## Motivation and Context

A client sending `{oops` or an over-limit body got an HTTP 500 (and the +500 page for HTML accepts), misclassifying client mistakes as server faults and polluting error monitoring. Stamped errors rather than thrown `Response`s keep `try/catch` around `await context.body` seeing a normal `Error`. The README now states the 400/413 behavior.

## Checklist:

- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
