### PR TITLE
fix: respond 415 for content-types no configured body option handles

### DIFF
--- a/.changeset/body-415-unconfigured.md
+++ b/.changeset/body-415-unconfigured.md
@@ -1,0 +1,5 @@
+---
+"@marko/run": patch
+---
+
+Requests whose `Content-Type` matches no configured body option now respond 415 instead of being parsed by the form fallback and skipping validation.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -2,12 +2,6 @@
 
 Out-of-scope defects noticed while working on something else. Format and rules: [README.md](README.md).
 
-## Reject unconfigured content-types in readBody instead of falling back to form parsing
-
-`packages/run/src/runtime/internal.ts` › `readBody` | 2026-07-18 | impact:med | effort:med
-
-In `readBody`, the form branch (internal.ts:156-178) is the unconditional fallback for every non-`application/json` content-type and uses `route.options.form ?? {}` — so on a route that declares only the `json` body option, a POST with `content-type: text/plain` (or anything else) is parsed as urlencoded and `context.body` resolves to an object that skipped the json validator entirely. Repro: on a `Run.POST({ json: validator }, ...)` handler, `curl -X POST -H 'content-type: text/plain' -d 'hi' ...` yields `context.body = {"hi":""}` with a 200 and the validator never runs. This contradicts packages/run/README.md:569-570 ("`json` handles `application/json` requests; `form` handles `application/x-www-form-urlencoded` and `multipart/form-data`") and makes the inferred TypeScript type of `context.body` (the json validator's return type) unsound. Respond 415 Unsupported Media Type for content-types no configured option handles — or at minimum only take the form path when the `form` option is actually configured.
-
 ## Pass the error message to buildErrorMessage in the dedup error logger
 
 `packages/run/src/vite/plugin.ts` › `configResolved` | 2026-07-18 | impact:med | effort:low

--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -570,6 +570,7 @@ export const POST = Run.POST(
 - `form` handles `application/x-www-form-urlencoded` and `multipart/form-data` requests. It can be a validator, or an options object `{ validator?, maxBytes?, maxParts?, maxFiles?, maxFileBytes?, onFile? }`. Repeated fields become arrays, and `onFile(context, file)` is called for each uploaded file in multipart requests.
 - Function validators resolve `context.body` to their return value; Standard Schema validators resolve it to a `[value, issues]` tuple; with no validator it resolves to the raw parsed body.
 - Requests exceeding the configured size limits are rejected with a `413` response; malformed bodies (invalid JSON, invalid encoding, unparsable multipart) are rejected with a `400`.
+- Requests whose `Content-Type` matches no configured body option are rejected with a `415`.
 
 ### Loading Data
 

--- a/packages/run/src/__tests__/fixtures/request-body-form/__snapshots__/dev.expected.md
+++ b/packages/run/src/__tests__/fixtures/request-body-form/__snapshots__/dev.expected.md
@@ -7,3 +7,6 @@ Page Rendered
 # Step 0
 page
 
+# Step 1
+page
+

--- a/packages/run/src/__tests__/fixtures/request-body-form/__snapshots__/preview.expected.md
+++ b/packages/run/src/__tests__/fixtures/request-body-form/__snapshots__/preview.expected.md
@@ -7,3 +7,6 @@ Page Rendered
 # Step 0
 page
 
+# Step 1
+page
+

--- a/packages/run/src/__tests__/fixtures/request-body-form/test.config.ts
+++ b/packages/run/src/__tests__/fixtures/request-body-form/test.config.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 
 import { Step, StepContext } from "../../main.test";
 
-export const steps: Step[] = [post];
+export const steps: Step[] = [post, postUnconfiguredContentType];
 
 async function post({ page }: StepContext) {
   const response = await page.fetch(page.url(), {
@@ -17,4 +17,13 @@ async function post({ page }: StepContext) {
   const json = await response.json();
 
   assert.equal(json.issues, null);
+}
+
+async function postUnconfiguredContentType({ page }: StepContext) {
+  const response = await page.fetch(page.url(), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ name: "MarkoRun", age: "7" }),
+  });
+  assert.equal(response.status, 415);
 }

--- a/packages/run/src/__tests__/fixtures/request-body-json/__snapshots__/dev.expected.md
+++ b/packages/run/src/__tests__/fixtures/request-body-json/__snapshots__/dev.expected.md
@@ -16,3 +16,6 @@ page
 # Step 3
 page
 
+# Step 4
+page
+

--- a/packages/run/src/__tests__/fixtures/request-body-json/__snapshots__/preview.expected.md
+++ b/packages/run/src/__tests__/fixtures/request-body-json/__snapshots__/preview.expected.md
@@ -16,3 +16,6 @@ page
 # Step 3
 page
 
+# Step 4
+page
+

--- a/packages/run/src/__tests__/fixtures/request-body-json/test.config.ts
+++ b/packages/run/src/__tests__/fixtures/request-body-json/test.config.ts
@@ -7,6 +7,7 @@ export const steps: Step[] = [
   postMalformed,
   postTooLarge,
   postBadEncoding,
+  postUnconfiguredContentType,
 ];
 
 async function postMalformed({ page }: StepContext) {
@@ -53,4 +54,13 @@ async function post({ page }: StepContext) {
   const json = await response.json();
 
   assert.equal(json.issues, null);
+}
+
+async function postUnconfiguredContentType({ page }: StepContext) {
+  const response = await page.fetch(page.url(), {
+    method: "POST",
+    headers: { "content-type": "text/plain" },
+    body: "hi",
+  });
+  assert.equal(response.status, 415);
 }

--- a/packages/run/src/runtime/internal.ts
+++ b/packages/run/src/runtime/internal.ts
@@ -626,6 +626,16 @@ async function readBodyWithLimit(request: Request, maxBytes: number) {
   }
 }
 
+// The `Content-Type` media type, normalized per RFC 9110: parameters dropped,
+// case-insensitive. `undefined` when the request carries no content type.
+function getMediaType(request: Request) {
+  return request.headers
+    .get("Content-Type")
+    ?.split(";", 1)[0]
+    .trim()
+    .toLowerCase();
+}
+
 // Stamps the thrown error itself when there is one, keeping its message and
 // stack; `message` describes the failure for everything else.
 function clientError(message: string, status: number, thrown?: unknown) {
@@ -636,9 +646,9 @@ function clientError(message: string, status: number, thrown?: unknown) {
 
 async function readBody(route: RouteMatch, context: Context) {
   const { request } = context;
-  const contentType = request.headers.get("Content-Type");
-  if (contentType?.includes("application/json")) {
-    const { maxBytes = defaultMaxBytes, validator } = route.options.json ?? {};
+  const mediaType = getMediaType(request);
+  if (route.options.json && mediaType === "application/json") {
+    const { maxBytes = defaultMaxBytes, validator } = route.options.json;
     let json;
     try {
       json = JSON.parse(await readBodyWithLimit(request, maxBytes));
@@ -649,6 +659,13 @@ async function readBody(route: RouteMatch, context: Context) {
     }
     return validator ? validator(json) : json;
   }
+  const isMultipart = mediaType === "multipart/form-data";
+  if (
+    !route.options.form ||
+    !(isMultipart || mediaType === "application/x-www-form-urlencoded")
+  ) {
+    throw clientError("Unsupported content type", 415);
+  }
   const {
     maxParts = defaultMaxParts,
     maxFiles = defaultMaxFiles,
@@ -656,11 +673,11 @@ async function readBody(route: RouteMatch, context: Context) {
     maxBytes = maxFiles * maxFileBytes,
     onFile,
     validator,
-  } = route.options.form ?? {};
+  } = route.options.form;
   let data;
   try {
     data = searchParamsToObject(
-      contentType?.includes("multipart/form-data")
+      isMultipart
         ? await parseFormData(
             request,
             {


### PR DESCRIPTION
## Description

`@marko/run`: `readBody` now takes the json path only when the route configures `json` and the form path only when it configures `form` and the content-type is `application/x-www-form-urlencoded` or `multipart/form-data`; anything else answers a bare 415 via the status-stamped error machinery from #257.

## Motivation and Context

The form branch was an unconditional fallback for every non-JSON content-type using `route.options.form ?? {}`, so a `text/plain` POST to a json-only route parsed as urlencoded, resolved `context.body` to an object that skipped the validator, and returned 200 — contradicting the README and making the inferred type of `context.body` unsound. The json branch similarly parsed JSON on form-only routes without a validator.

## Checklist:

- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
