### PR TITLE
fix: include the error message in deduplicated dev error output

### DIFF
--- a/.changeset/dedup-error-message.md
+++ b/.changeset/dedup-error-message.md
@@ -1,0 +1,5 @@
+---
+"@marko/run": patch
+---
+
+Deduplicated dev-server errors print their message line again instead of a bare stack trace.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -2,12 +2,6 @@
 
 Out-of-scope defects noticed while working on something else. Format and rules: [README.md](README.md).
 
-## Pass the error message to buildErrorMessage in the dedup error logger
-
-`packages/run/src/vite/plugin.ts` › `configResolved` | 2026-07-18 | impact:med | effort:low
-
-The `configResolved` logger override dedupes repeated errors but re-renders them with `buildErrorMessage(options.error)` and no `args`. Vite puts the human-readable message into that second parameter (it calls `buildErrorMessage(err, [red("Internal server error: " + err.message)])`) and its `cleanStack` keeps only `    at ...` frames, so the printed output contains no message line at all. Concretely: when the HMR websocket port 24678 is already taken (e.g. a second `marko-run dev` instance), the terminal shows a bare `at Server.setupListenHandle ... DevEnvironment.listen` stack with no `Error: listen EADDRINUSE` text, which is nearly undiagnosable. Fix: `buildErrorMessage(options.error, [options.error.message])`, mirroring `packages/run/src/adapter/dev-server.ts:163` which already passes a message line.
-
 ## Fix permanent 504 "Outdated Optimize Dep" for marko/debug/dom in dev when @cloudflare/vite-plugin shares the ssr environment
 
 `packages/run/src/vite/plugin.ts` › `config` | 2026-07-18 | impact:high | effort:high

--- a/packages/run/src/vite/plugin.ts
+++ b/packages/run/src/vite/plugin.ts
@@ -602,7 +602,11 @@ export default function markoRun(opts: Options = {}): Plugin[] {
             baseError.call(this, msg, options);
           } else if (!seenErrors.has(options.error.message)) {
             seenErrors.add(options.error.message);
-            console.error(buildErrorMessage(options.error));
+            console.error(
+              buildErrorMessage(options.error, [
+                `\x1b[31;1m${options.error.message}\x1b[0m`,
+              ]),
+            );
           }
         };
       },


### PR DESCRIPTION
## Description

`@marko/run`: the `configResolved` dedup error logger now passes the error's message line to `buildErrorMessage`, styled the same way as the adapter dev-server's existing call.

## Motivation and Context

Vite's `buildErrorMessage` only prints the message via its second argument and its `cleanStack` keeps just the `at ...` frames, so deduplicated errors printed a bare stack with no message — e.g. a second `marko-run dev` instance hitting the taken HMR port showed a stack with no `Error: listen EADDRINUSE` text.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
