### PR TITLE
fix: report the real package version from the CLI and startup banner

### DIFF
--- a/.changeset/cli-real-version.md
+++ b/.changeset/cli-real-version.md
@@ -1,0 +1,5 @@
+---
+"@marko/run": patch
+---
+
+`marko-run --version` and the startup banner report the installed package version instead of `0.0.1` / an inlined build-time value.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -2,12 +2,6 @@
 
 Out-of-scope defects noticed while working on something else. Format and rules: [README.md](README.md).
 
-## Report the real package version from the marko-run CLI instead of hardcoded "0.0.1"
-
-`packages/run/src/cli/index.ts` › `prog` | 2026-07-18 | impact:med | effort:low
-
-The sade program is initialized with `.version("0.0.1")`, so `npx marko-run --version` prints `marko-run, 0.0.1` regardless of the installed release — the literal ships verbatim in published `dist/cli/index.mjs` (confirmed in the 0.6.6 tarball, and the source line is unchanged at HEAD). This makes version checks during bug triage misleading: a user asked "what version of the CLI are you on?" gets a bogus answer. Inject the version from the package's own `package.json` at bundle time (a define/replace step in the dist build) or read it at runtime before constructing the sade program.
-
 ## `@marko/run` SSR build can bundle a dependency's private transitive CJS deps under pnpm and crash on ESM/CJS interop
 
 `packages/run/src/vite/plugin.ts` › `config` (ssr.noExternal / resolve.conditions) | 2026-07-23 | impact:med | effort:med

--- a/agent-feedback/cleanup.md
+++ b/agent-feedback/cleanup.md
@@ -38,12 +38,6 @@ The edge entry's `excludedPath: ["/assets/*"]` hardcodes Vite's default `build.a
 
 `logRoutesTable` pushes "handler" into a row's entry chain whenever `route.handler` exists, regardless of verb: a route with `+page.marko` and a `+handler.ts` exporting only `POST` prints its GET row as `handler -> page`, implying a GET handler runs before the page when none exists. The per-verb information is already available — `getVerbs` derives verbs from `route.handler?.verbs` (packages/run/src/vite/utils/route.ts:13) — so the cell could check `route.handler.verbs.includes(verb)` before pushing. Cosmetic, but the table is the main at-a-glance view of each route's execution chain.
 
-## Read the banner version at runtime instead of inlining npm_package_version at build time
-
-`packages/run/scripts/build.ts` › `opts` | 2026-07-18 | impact:low | effort:low
-
-The startup banner (`packages/run/src/adapter/utils.ts:38`) reads `process.env.npm_package_version`, which esbuild `define` freezes at package-build time; the published `0.11.0-rc.10` tarball contains the literal `v${"0.11.0-rc.9"}` in `dist/adapter/index.js`, so every rc.10 install printed the previous version at startup (verify with `npm pack @marko/run@0.11.0-rc.10` and grep the dist). The root `@ci:version` script runs the build before `changeset version`, so any release that publishes a dist built before the bump ships a stale banner again. Read the version from the package's own package.json at runtime, or have release CI assert the inlined value matches the manifest.
-
 ## Reconcile the two in-flight-slot guards in the dev request logger so the `⁺` slot stops leaking
 
 `packages/run/src/adapter/logger.ts` › `logger` | 2026-08-03 | impact:low | effort:low

--- a/packages/run/scripts/build.ts
+++ b/packages/run/scripts/build.ts
@@ -22,11 +22,6 @@ const opts: BuildOptions = {
   target: ["node14"],
   bundle: true,
   treeShaking: true,
-  define: {
-    "process.env.npm_package_version": JSON.stringify(
-      process.env.npm_package_version || "",
-    ),
-  },
   plugins: [
     {
       name: "external-modules",

--- a/packages/run/src/adapter/utils.ts
+++ b/packages/run/src/adapter/utils.ts
@@ -1,8 +1,31 @@
+import fs from "fs";
 import kleur from "kleur";
+import path from "path";
 import supportsColor from "supports-color";
+import { fileURLToPath } from "url";
 import type { Rolldown } from "vite";
 
 type RolldownError = Rolldown.RolldownError;
+
+let version: string | undefined;
+
+/**
+ * The version of the installed `@marko/run` package, read at runtime from its
+ * own package.json — a build-time inline goes stale whenever a release builds
+ * before the version bump. Works from both the CJS and ESM dist outputs.
+ */
+export function getPackageVersion() {
+  if (version === undefined) {
+    const dir =
+      typeof __dirname === "string"
+        ? __dirname
+        : path.dirname(fileURLToPath(import.meta.url));
+    version = JSON.parse(
+      fs.readFileSync(path.join(dir, "../../package.json"), "utf8"),
+    ).version as string;
+  }
+  return version;
+}
 
 export function prepareError(err: Error | RolldownError) {
   return {
@@ -20,9 +43,7 @@ export function logInfoBox(address: string, explorer?: string) {
   const color = !!supportsColor.stdout;
 
   let message = kleur.bold("Marko Run");
-  if (process.env.npm_package_version !== "") {
-    message += ` v${process.env.npm_package_version}`;
-  }
+  message += ` v${getPackageVersion()}`;
   message += "\n\n";
   message += kleur.dim("Server listening at");
   message += "\n";

--- a/packages/run/src/cli/index.ts
+++ b/packages/run/src/cli/index.ts
@@ -2,6 +2,7 @@
 
 import sade from "sade";
 
+import { getPackageVersion } from "../adapter/utils";
 import {
   build,
   defaultConfigFileBases,
@@ -12,7 +13,7 @@ import {
 } from "./commands";
 
 const prog = sade("marko-run")
-  .version("0.0.1")
+  .version(getPackageVersion())
   .option(
     "-c, --config",
     `Provide path to a Vite config file (by default looks for a file starting with ${defaultConfigFileBases.join(


### PR DESCRIPTION
## Description

`@marko/run`: adds a `getPackageVersion()` utility that reads the package's own `package.json` at runtime (memoized, working from both the CJS and ESM dist outputs), used by `marko-run --version` and the startup banner. The `npm_package_version` build-time define is removed.

## Motivation and Context

The CLI shipped a hardcoded `.version("0.0.1")`, so `marko-run --version` was useless for triage. The banner inlined `npm_package_version` at package-build time, which printed a stale (or empty) version whenever a release built before the version bump — reading at runtime fixes both from one place.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
