### PR TITLE
fix: stop route option merging from mutating shared middleware options

### DIFF
--- a/.changeset/merge-options-mutation.md
+++ b/.changeset/merge-options-mutation.md
@@ -1,0 +1,5 @@
+---
+"@marko/run": patch
+---
+
+Options declared in `+middleware` no longer leak between routes, and a handler declaring only a size limit keeps the middleware's validator. A key explicitly set to `undefined` now overrides the inherited option; an absent key leaves it in place.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -2,12 +2,6 @@
 
 Out-of-scope defects noticed while working on something else. Format and rules: [README.md](README.md).
 
-## Stop `mergeOptions` from mutating the shared `+middleware` options object — one route's body validator and limits leak into every later route
-
-`packages/run/src/runtime/internal.ts` › `mergeOptions` | 2026-08-03 | impact:high | effort:med
-
-`mergeOptions` seeds `merged[key]` with the first source's nested option object by reference and folds later sources in with `Object.assign(merged[key], option)`, so it writes into the objects it was handed — and generated code makes that first source a cross-route singleton, since `renderMiddleware` (`packages/run/src/vite/codegen/index.ts`) emits one module-scoped `mware<id> = normalizeHandler(...)` per `+middleware` (seven route modules merge `mware4` in `packages/run/src/vite/__tests__/fixtures/build-routes/__snapshots__/build-routes.expected.routes.md`). With `export default Run.ALL({ json: { maxBytes: 100 } }, fn)` in a root `+middleware`, merging one route's `Run.POST({ json: schema }, fn)` permanently rewrites the middleware's `options.json` to `{ maxBytes: 1048576, validator: schema }`, so every route merged afterwards — including routes that declare no body options — has `readBody` validate against that unrelated schema and inherit the wrong size limit. `createDefineHandler` compounds it by materializing `defaultMaxBytes`/`defaultMaxFiles`/`defaultMaxParts` plus an explicit `validator: undefined` into `handler.options`, so a handler declaring only `maxBytes` drops the middleware's validator, contradicting the README's "Options declared in middleware and handlers along a route are merged". Fix by shallow-copying nested option objects (`merged[key] = { ...(merged[key] as object), ...option }`) and splitting the raw merge from the defaulting step, so declared options stay un-defaulted until the per-route merge builds its result.
-
 ## Skip a verb-specific middleware's validation options for the verbs it doesn't run on
 
 `packages/run/src/vite/codegen/index.ts` › `writeRouteOptions` | 2026-08-03 | impact:med | effort:med

--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -540,7 +540,7 @@ export const GET = Run.GET(
 
 `context.params` and `context.search` are computed lazily from the validators. Function validators replace the value with whatever they return. Standard Schema validators produce a `[value, issues]` tuple, where `issues` is `undefined` when validation succeeds. Schema validation must be synchronous.
 
-Options declared in middleware and handlers along a route are merged, so shared validation can live in a `+middleware` file.
+Options declared in middleware and handlers along a route are merged, so shared validation can live in a `+middleware` file. A key explicitly set to `undefined` overrides the inherited value; omitting the key leaves it in place.
 
 ### Request Bodies
 

--- a/packages/run/src/__tests__/merge-options.test.ts
+++ b/packages/run/src/__tests__/merge-options.test.ts
@@ -1,12 +1,12 @@
 import assert from "assert";
 
-import { mergeOptions } from "../runtime/internal";
+import { mergeOptions, normalizeOptions } from "../runtime/internal";
 
-describe("mergeOptions", () => {
+describe("normalizeOptions", () => {
   it("should enable body parsing with the defaults for a bare truthy option", () => {
     // The types forbid `json: true`, but plain-JS handlers have no type
     // guard and it is the natural way to write "parse the body".
-    const { json, form } = mergeOptions({ json: true, form: true } as any);
+    const { json, form } = normalizeOptions({ json: true, form: true } as any);
 
     assert.equal(json!.maxBytes, 1024 * 1024);
     assert.equal(json!.validator, undefined);
@@ -17,7 +17,7 @@ describe("mergeOptions", () => {
 
   it("should treat a function as the validator", () => {
     const validator = (input: unknown) => [input, undefined];
-    const { json } = mergeOptions({ json: validator } as any);
+    const { json } = normalizeOptions({ json: validator } as any);
 
     assert.equal(json!.validator, validator);
     assert.equal(json!.maxBytes, 1024 * 1024);
@@ -27,14 +27,14 @@ describe("mergeOptions", () => {
     const schema = {
       "~standard": { validate: (value: unknown) => ({ value }) },
     };
-    const { form } = mergeOptions({ form: schema } as any);
+    const { form } = normalizeOptions({ form: schema } as any);
 
     assert.equal(typeof form!.validator, "function");
   });
 
   it("should drop a validator that is neither a function nor a schema", () => {
     // Wrapping one would defer the crash to the first validation.
-    const { params, search, json, form } = mergeOptions({
+    const { params, search, json, form } = normalizeOptions({
       params: true,
       search: "yes",
       json: { validator: true },
@@ -57,7 +57,7 @@ describe("mergeOptions", () => {
           value.page ? { value: { page: Number(value.page) } } : { issues },
       },
     };
-    const { params, search } = mergeOptions({
+    const { params, search } = normalizeOptions({
       params: fn,
       search: schema,
     } as any);
@@ -70,7 +70,7 @@ describe("mergeOptions", () => {
   });
 
   it("should take an options object as options", () => {
-    const { json, form } = mergeOptions({
+    const { json, form } = normalizeOptions({
       json: { maxBytes: 5 },
       form: { maxFiles: 2, maxFileBytes: 10 },
     } as any);
@@ -78,5 +78,70 @@ describe("mergeOptions", () => {
     assert.equal(json!.maxBytes, 5);
     assert.equal(form!.maxFiles, 2);
     assert.equal(form!.maxBytes, 20);
+  });
+});
+
+describe("mergeOptions", () => {
+  it("should not mutate the source options", () => {
+    // A root +middleware's options object is a module-scoped singleton merged
+    // into every route below it.
+    const middleware = { json: { maxBytes: 100 } };
+    const validator = (input: unknown) => [input, undefined];
+    mergeOptions(middleware, { json: { validator } });
+
+    assert.deepEqual(middleware, { json: { maxBytes: 100 } });
+  });
+
+  it("should keep a middleware validator when the handler sets only limits", () => {
+    const validator = (input: unknown) => [input, undefined];
+    const middleware = { json: { validator, maxBytes: 100 } };
+    const handler = (Run.POST as any)({ json: { maxBytes: 200 } }, () => {});
+    const { json } = normalizeOptions(middleware as any, handler as any);
+
+    assert.equal(json!.validator, validator);
+    assert.equal(json!.maxBytes, 200);
+  });
+
+  it("should merge a bare validator with an options object", () => {
+    const validator = (input: unknown) => [input, undefined];
+    const { json } = normalizeOptions(
+      { json: { maxBytes: 100 } } as any,
+      { json: validator } as any,
+    );
+
+    assert.equal(json!.validator, validator);
+    assert.equal(json!.maxBytes, 100);
+  });
+
+  it("should let an explicitly present undefined key override an inherited option", () => {
+    const validator = (input: unknown) => [input, undefined];
+    const { json, search } = normalizeOptions(
+      { json: validator, search: validator } as any,
+      { json: undefined } as any,
+    );
+
+    assert.equal(json, undefined);
+    assert.equal(typeof search, "function");
+  });
+
+  it("should leave inherited options alone when the key is absent", () => {
+    const validator = (input: unknown) => [input, undefined];
+    const { json } = normalizeOptions({ json: validator } as any, {} as any);
+
+    assert.equal(typeof json!.validator, "function");
+  });
+
+  it("should not leak one route's options into a sibling merge", () => {
+    const middleware = { json: { maxBytes: 100 } };
+    const validator = (input: unknown) => [input, undefined];
+    const routeA = normalizeOptions(
+      middleware as any,
+      { json: { validator } } as any,
+    );
+    const routeB = normalizeOptions(middleware as any, {} as any);
+
+    assert.equal(routeA.json!.validator, validator);
+    assert.equal(routeB.json!.validator, undefined);
+    assert.equal(routeB.json!.maxBytes, 100);
   });
 });

--- a/packages/run/src/runtime/internal.ts
+++ b/packages/run/src/runtime/internal.ts
@@ -431,13 +431,16 @@ const defaultMaxBytes = 1024 * 1024;
 const defaultMaxParts = 1000;
 const defaultMaxFiles = 20;
 
-export function mergeOptions(
-  ...arr: (
-    | NormalizedHandler<Context, "ALL", any, HandlerOptions>
-    | HandlerFunction
-    | HandlerOptions
-  )[]
-) {
+type MergeOptionsInput =
+  | NormalizedHandler<Context, "ALL", any, HandlerOptions>
+  | HandlerFunction
+  | HandlerOptions;
+
+// Merges without defaulting or normalizing, so intermediate merges (a
+// handler's own options) stay exactly what was declared and only the final
+// per-route merge materializes defaults. Never writes into its inputs — the
+// first source is often a `+middleware` options object shared across routes.
+export function mergeOptions(...arr: MergeOptionsInput[]) {
   const merged: HandlerOptions = {};
   for (const item of arr) {
     let options: HandlerOptions;
@@ -450,14 +453,27 @@ export function mergeOptions(
     }
     for (const k in options) {
       const key = k as keyof typeof options;
-      const option = options[key];
-      if (typeof option === "object" && typeof merged[key] === "object") {
-        Object.assign(merged[key], option);
-      } else if (option) {
-        merged[key] = option as any;
+      let option: unknown = options[key];
+      // A bare validator merges with an options object instead of replacing
+      // it, matching the documented middleware/handler option merging.
+      if ((key === "json" || key === "form") && isValidator(option)) {
+        option = { validator: option };
       }
+      const prev = merged[key];
+      // A key explicitly present with a falsy value overrides the inherited
+      // one — different from the key being absent, which leaves it alone.
+      merged[key] = (
+        option && typeof option === "object" && prev && typeof prev === "object"
+          ? { ...prev, ...option }
+          : option
+      ) as any;
     }
   }
+  return merged;
+}
+
+export function normalizeOptions(...arr: MergeOptionsInput[]) {
+  const merged = mergeOptions(...arr);
 
   const result = {
     params: normalizeValidator(merged.params),

--- a/packages/run/src/vite/__tests__/fixtures/build-routes/__snapshots__/build-routes.expected.routes.md
+++ b/packages/run/src/vite/__tests__/fixtures/build-routes/__snapshots__/build-routes.expected.routes.md
@@ -31,12 +31,12 @@ import Page from "../../src/routes/_protected/_home/+page.marko";
 ```
 ### Handler
 ```js
-import { call, mergeOptions, render, stripResponseBody } from "virtual:marko-run/runtime/internal";
+import { call, normalizeOptions, render, stripResponseBody } from "virtual:marko-run/runtime/internal";
 import { mware4, mware5, mware7 } from "virtual:marko-run/__marko-run__middleware.js";
 import page from "./dist/.marko-run/index.marko";
 
-export const get3_options = mergeOptions(mware4, mware5, mware7);
-export const head3_options = mergeOptions(mware4, mware5, mware7);
+export const get3_options = normalizeOptions(mware4, mware5, mware7);
+export const head3_options = normalizeOptions(mware4, mware5, mware7);
 
 export function get3(context) {
 	const __page = (data) => render(context, page, {}, data);
@@ -66,7 +66,7 @@ import Page from "../../src/routes/_protected/_home/new/+page.marko";
 ```
 ### Handler
 ```js
-import { normalizeHandler, normalizeMeta, call, mergeOptions, render, stripResponseBody } from "virtual:marko-run/runtime/internal";
+import { normalizeHandler, normalizeMeta, call, normalizeOptions, render, stripResponseBody } from "virtual:marko-run/runtime/internal";
 import { mware4, mware5, mware7 } from "virtual:marko-run/__marko-run__middleware.js";
 import { POST } from "./src/routes/_protected/_home/new/+handler.ts";
 import page from "./dist/.marko-run/new.marko";
@@ -76,9 +76,9 @@ const postHandler = normalizeHandler(POST, 'POST');
 
 export const { GET: get4_meta, GET: head4_meta, POST: post4_meta } = normalizeMeta(meta4);
 
-export const get4_options = mergeOptions(mware4, mware5, mware7);
-export const head4_options = mergeOptions(mware4, mware5, mware7);
-export const post4_options = mergeOptions(mware4, mware5, mware7, postHandler);
+export const get4_options = normalizeOptions(mware4, mware5, mware7);
+export const head4_options = normalizeOptions(mware4, mware5, mware7);
+export const post4_options = normalizeOptions(mware4, mware5, mware7, postHandler);
 
 export function get4(context) {
 	const __page = (data) => render(context, page, {}, data);
@@ -116,7 +116,7 @@ import Page from "../../src/routes/_protected/_home/notes/$id/+page.marko";
 ```
 ### Handler
 ```js
-import { normalizeHandler, call, mergeOptions, render, noContent, stripResponseBody } from "virtual:marko-run/runtime/internal";
+import { normalizeHandler, call, normalizeOptions, render, noContent, stripResponseBody } from "virtual:marko-run/runtime/internal";
 import { mware4, mware5, mware7, mware13 } from "virtual:marko-run/__marko-run__middleware.js";
 import { PUT, POST, DELETE } from "./src/routes/_protected/_home/notes/$id/+handler.ts";
 import page from "./dist/.marko-run/notes.$.marko";
@@ -125,11 +125,11 @@ const putHandler = normalizeHandler(PUT, 'PUT');
 const postHandler = normalizeHandler(POST, 'POST');
 const deleteHandler = normalizeHandler(DELETE, 'DELETE');
 
-export const get5_options = mergeOptions(mware4, mware5, mware7, mware13);
-export const head5_options = mergeOptions(mware4, mware5, mware7, mware13);
-export const post5_options = mergeOptions(mware4, mware5, mware7, mware13, postHandler);
-export const put5_options = mergeOptions(mware4, mware5, mware7, mware13, putHandler);
-export const delete5_options = mergeOptions(mware4, mware5, mware7, mware13, deleteHandler);
+export const get5_options = normalizeOptions(mware4, mware5, mware7, mware13);
+export const head5_options = normalizeOptions(mware4, mware5, mware7, mware13);
+export const post5_options = normalizeOptions(mware4, mware5, mware7, mware13, postHandler);
+export const put5_options = normalizeOptions(mware4, mware5, mware7, mware13, putHandler);
+export const delete5_options = normalizeOptions(mware4, mware5, mware7, mware13, deleteHandler);
 
 export function get5(context) {
 	const __page = (data) => render(context, page, {}, data);
@@ -173,7 +173,7 @@ export function delete5(context) {
 ### Path: ``/notes/$id/comments``
 ### Handler
 ```js
-import { normalizeHandler, normalizeMeta, call, mergeOptions, noContent } from "virtual:marko-run/runtime/internal";
+import { normalizeHandler, normalizeMeta, call, normalizeOptions, noContent } from "virtual:marko-run/runtime/internal";
 import { mware4, mware5, mware7, mware13 } from "virtual:marko-run/__marko-run__middleware.js";
 import { PUT, POST, DELETE } from "./src/routes/_protected/_home/notes/$id/comments/+handler.ts";
 import meta6 from "./src/routes/_protected/_home/notes/$id/comments/+meta.ts";
@@ -184,9 +184,9 @@ const deleteHandler = normalizeHandler(DELETE, 'DELETE');
 
 export const { POST: post6_meta, PUT: put6_meta, DELETE: delete6_meta } = normalizeMeta(meta6);
 
-export const post6_options = mergeOptions(mware4, mware5, mware7, mware13, postHandler);
-export const put6_options = mergeOptions(mware4, mware5, mware7, mware13, putHandler);
-export const delete6_options = mergeOptions(mware4, mware5, mware7, mware13, deleteHandler);
+export const post6_options = normalizeOptions(mware4, mware5, mware7, mware13, postHandler);
+export const put6_options = normalizeOptions(mware4, mware5, mware7, mware13, putHandler);
+export const delete6_options = normalizeOptions(mware4, mware5, mware7, mware13, deleteHandler);
 
 export function post6(context) {
 	const __postHandler = (data) => call(postHandler, noContent, context, data);
@@ -217,14 +217,14 @@ export function delete6(context) {
 ### Path: ``/callback/oauth2``
 ### Handler
 ```js
-import { normalizeHandler, call, mergeOptions, noContent, stripResponseBody } from "virtual:marko-run/runtime/internal";
+import { normalizeHandler, call, normalizeOptions, noContent, stripResponseBody } from "virtual:marko-run/runtime/internal";
 import { mware4 } from "virtual:marko-run/__marko-run__middleware.js";
 import { GET } from "./src/routes/callback/oauth2/+handler.ts";
 
 const getHandler = normalizeHandler(GET, 'GET');
 
-export const get7_options = mergeOptions(mware4, getHandler);
-export const head7_options = mergeOptions(mware4);
+export const get7_options = normalizeOptions(mware4, getHandler);
+export const head7_options = normalizeOptions(mware4);
 
 export function get7(context) {
 	const __getHandler = (data) => call(getHandler, noContent, context, data);
@@ -249,7 +249,7 @@ import Page from "../../src/routes/my/+page.marko";
 ```
 ### Handler
 ```js
-import { normalizeHandler, call, mergeOptions, render, stripResponseBody } from "virtual:marko-run/runtime/internal";
+import { normalizeHandler, call, normalizeOptions, render, stripResponseBody } from "virtual:marko-run/runtime/internal";
 import { mware4 } from "virtual:marko-run/__marko-run__middleware.js";
 import { GET, HEAD } from "./src/routes/my/+handler.ts";
 import page from "./dist/.marko-run/my.marko";
@@ -257,8 +257,8 @@ import page from "./dist/.marko-run/my.marko";
 const getHandler = normalizeHandler(GET, 'GET');
 const headHandler = normalizeHandler(HEAD, 'HEAD');
 
-export const get8_options = mergeOptions(mware4, getHandler);
-export const head8_options = mergeOptions(mware4, headHandler);
+export const get8_options = normalizeOptions(mware4, getHandler);
+export const head8_options = normalizeOptions(mware4, headHandler);
 
 export function get8(context) {
 	const __page = (data) => render(context, page, {}, data);
@@ -277,14 +277,14 @@ export function head8(context) {
 ### Path: ``/$$match``
 ### Handler
 ```js
-import { normalizeHandler, call, mergeOptions, noContent, stripResponseBody } from "virtual:marko-run/runtime/internal";
+import { normalizeHandler, call, normalizeOptions, noContent, stripResponseBody } from "virtual:marko-run/runtime/internal";
 import { mware4 } from "virtual:marko-run/__marko-run__middleware.js";
 import { GET } from "./src/routes/$$match/+handler.ts";
 
 const getHandler = normalizeHandler(GET, 'GET');
 
-export const get9_options = mergeOptions(mware4, getHandler);
-export const head9_options = mergeOptions(mware4);
+export const get9_options = normalizeOptions(mware4, getHandler);
+export const head9_options = normalizeOptions(mware4);
 
 export function get9(context) {
 	const __getHandler = (data) => call(getHandler, noContent, context, data);

--- a/packages/run/src/vite/__tests__/fixtures/flat-routes/__snapshots__/flat-routes.expected.routes.md
+++ b/packages/run/src/vite/__tests__/fixtures/flat-routes/__snapshots__/flat-routes.expected.routes.md
@@ -44,16 +44,16 @@ import Page from "../../src/routes/foo,$id,$$rest,+page.marko";
 ```
 ### Handler
 ```js
-import { normalizeHandler, call, mergeOptions, render, stripResponseBody } from "virtual:marko-run/runtime/internal";
+import { normalizeHandler, call, normalizeOptions, render, stripResponseBody } from "virtual:marko-run/runtime/internal";
 import { GET, POST } from "./src/routes/foo,(a,b).(c,d)+handler.marko";
 import page from "./dist/.marko-run/foo.marko";
 
 const getHandler = normalizeHandler(GET, 'GET');
 const postHandler = normalizeHandler(POST, 'POST');
 
-export const get2_options = mergeOptions(getHandler);
+export const get2_options = normalizeOptions(getHandler);
 export const head2_options = {};
-export const post2_options = mergeOptions(postHandler);
+export const post2_options = normalizeOptions(postHandler);
 
 export function get2(context) {
 	const __page = (data) => render(context, page, {}, data);
@@ -80,12 +80,12 @@ import Page from "../../src/routes/foo,$id,$$rest,+page.marko";
 ```
 ### Handler
 ```js
-import { call, mergeOptions, render, stripResponseBody } from "virtual:marko-run/runtime/internal";
+import { call, normalizeOptions, render, stripResponseBody } from "virtual:marko-run/runtime/internal";
 import { mware3 } from "virtual:marko-run/__marko-run__middleware.js";
 import page from "./dist/.marko-run/$.marko";
 
-export const get3_options = mergeOptions(mware3);
-export const head3_options = mergeOptions(mware3);
+export const get3_options = normalizeOptions(mware3);
+export const head3_options = normalizeOptions(mware3);
 
 export function get3(context) {
 	const __page = (data) => render(context, page, {}, data);
@@ -126,15 +126,15 @@ export function head4(context) {
 ### Path: ``/a/c``
 ### Handler
 ```js
-import { normalizeHandler, call, mergeOptions, noContent, stripResponseBody } from "virtual:marko-run/runtime/internal";
+import { normalizeHandler, call, normalizeOptions, noContent, stripResponseBody } from "virtual:marko-run/runtime/internal";
 import { GET, POST } from "./src/routes/foo,(a,b).(c,d)+handler.marko";
 
 const getHandler = normalizeHandler(GET, 'GET');
 const postHandler = normalizeHandler(POST, 'POST');
 
-export const get5_options = mergeOptions(getHandler);
+export const get5_options = normalizeOptions(getHandler);
 export const head5_options = {};
-export const post5_options = mergeOptions(postHandler);
+export const post5_options = normalizeOptions(postHandler);
 
 export function get5(context) {
 	return call(getHandler, noContent, context);
@@ -153,16 +153,16 @@ export function post5(context) {
 ### Path: ``/a/d``
 ### Handler
 ```js
-import { normalizeHandler, call, mergeOptions, noContent, stripResponseBody } from "virtual:marko-run/runtime/internal";
+import { normalizeHandler, call, normalizeOptions, noContent, stripResponseBody } from "virtual:marko-run/runtime/internal";
 import { mware3 } from "virtual:marko-run/__marko-run__middleware.js";
 import { GET, POST } from "./src/routes/foo,(a,b).(c,d)+handler.marko";
 
 const getHandler = normalizeHandler(GET, 'GET');
 const postHandler = normalizeHandler(POST, 'POST');
 
-export const get6_options = mergeOptions(mware3, getHandler);
-export const head6_options = mergeOptions(mware3);
-export const post6_options = mergeOptions(mware3, postHandler);
+export const get6_options = normalizeOptions(mware3, getHandler);
+export const head6_options = normalizeOptions(mware3);
+export const post6_options = normalizeOptions(mware3, postHandler);
 
 export function get6(context) {
 	const __getHandler = (data) => call(getHandler, noContent, context, data);
@@ -183,15 +183,15 @@ export function post6(context) {
 ### Path: ``/b/c``
 ### Handler
 ```js
-import { normalizeHandler, call, mergeOptions, noContent, stripResponseBody } from "virtual:marko-run/runtime/internal";
+import { normalizeHandler, call, normalizeOptions, noContent, stripResponseBody } from "virtual:marko-run/runtime/internal";
 import { GET, POST } from "./src/routes/foo,(a,b).(c,d)+handler.marko";
 
 const getHandler = normalizeHandler(GET, 'GET');
 const postHandler = normalizeHandler(POST, 'POST');
 
-export const get7_options = mergeOptions(getHandler);
+export const get7_options = normalizeOptions(getHandler);
 export const head7_options = {};
-export const post7_options = mergeOptions(postHandler);
+export const post7_options = normalizeOptions(postHandler);
 
 export function get7(context) {
 	return call(getHandler, noContent, context);
@@ -210,15 +210,15 @@ export function post7(context) {
 ### Path: ``/b/d``
 ### Handler
 ```js
-import { normalizeHandler, call, mergeOptions, noContent, stripResponseBody } from "virtual:marko-run/runtime/internal";
+import { normalizeHandler, call, normalizeOptions, noContent, stripResponseBody } from "virtual:marko-run/runtime/internal";
 import { GET, POST } from "./src/routes/foo,(a,b).(c,d)+handler.marko";
 
 const getHandler = normalizeHandler(GET, 'GET');
 const postHandler = normalizeHandler(POST, 'POST');
 
-export const get8_options = mergeOptions(getHandler);
+export const get8_options = normalizeOptions(getHandler);
 export const head8_options = {};
-export const post8_options = mergeOptions(postHandler);
+export const post8_options = normalizeOptions(postHandler);
 
 export function get8(context) {
 	return call(getHandler, noContent, context);

--- a/packages/run/src/vite/__tests__/fixtures/get-post/__snapshots__/get-post.expected.routes.md
+++ b/packages/run/src/vite/__tests__/fixtures/get-post/__snapshots__/get-post.expected.routes.md
@@ -19,7 +19,7 @@ import Page from "../../src/routes/+page.marko";
 ```
 ### Handler
 ```js
-import { normalizeHandler, call, mergeOptions, render, stripResponseBody } from "virtual:marko-run/runtime/internal";
+import { normalizeHandler, call, normalizeOptions, render, stripResponseBody } from "virtual:marko-run/runtime/internal";
 import { mware3 } from "virtual:marko-run/__marko-run__middleware.js";
 import { GET, POST } from "./src/routes/+handler.marko";
 import page from "./dist/.marko-run/index.marko";
@@ -27,9 +27,9 @@ import page from "./dist/.marko-run/index.marko";
 const getHandler = normalizeHandler(GET, 'GET');
 const postHandler = normalizeHandler(POST, 'POST');
 
-export const get1_options = mergeOptions(mware3, getHandler);
-export const head1_options = mergeOptions(mware3);
-export const post1_options = mergeOptions(mware3, postHandler);
+export const get1_options = normalizeOptions(mware3, getHandler);
+export const head1_options = normalizeOptions(mware3);
+export const post1_options = normalizeOptions(mware3, postHandler);
 
 export function get1(context) {
 	const __page = (data) => render(context, page, {}, data);

--- a/packages/run/src/vite/__tests__/fixtures/meta-files-with-verbs/__snapshots__/meta-files-with-verbs.expected.routes.md
+++ b/packages/run/src/vite/__tests__/fixtures/meta-files-with-verbs/__snapshots__/meta-files-with-verbs.expected.routes.md
@@ -4,7 +4,7 @@
 ### Path: ``/foo/bar``
 ### Handler
 ```js
-import { normalizeHandler, normalizeMeta, call, mergeOptions, noContent } from "virtual:marko-run/runtime/internal";
+import { normalizeHandler, normalizeMeta, call, normalizeOptions, noContent } from "virtual:marko-run/runtime/internal";
 import { PUT, POST, DELETE } from "./src/routes/foo/bar/+handler.ts";
 import meta1 from "./src/routes/foo/bar/+meta.ts";
 
@@ -14,9 +14,9 @@ const deleteHandler = normalizeHandler(DELETE, 'DELETE');
 
 export const { POST: post1_meta, PUT: put1_meta, DELETE: delete1_meta } = normalizeMeta(meta1);
 
-export const post1_options = mergeOptions(postHandler);
-export const put1_options = mergeOptions(putHandler);
-export const delete1_options = mergeOptions(deleteHandler);
+export const post1_options = normalizeOptions(postHandler);
+export const put1_options = normalizeOptions(putHandler);
+export const delete1_options = normalizeOptions(deleteHandler);
 
 export function post1(context) {
 	return call(postHandler, noContent, context);
@@ -41,7 +41,7 @@ import Page from "../../src/routes/foo/baz/+page.marko";
 ```
 ### Handler
 ```js
-import { normalizeHandler, normalizeMeta, call, mergeOptions, render, noContent, stripResponseBody } from "virtual:marko-run/runtime/internal";
+import { normalizeHandler, normalizeMeta, call, normalizeOptions, render, noContent, stripResponseBody } from "virtual:marko-run/runtime/internal";
 import { PUT, POST, DELETE } from "./src/routes/foo/baz/+handler.ts";
 import page from "./dist/.marko-run/foo.baz.marko";
 import meta2 from "./src/routes/foo/baz/+meta.json";
@@ -54,9 +54,9 @@ export const { GET: get2_meta, GET: head2_meta, POST: post2_meta, PUT: put2_meta
 
 export const get2_options = {};
 export const head2_options = {};
-export const post2_options = mergeOptions(postHandler);
-export const put2_options = mergeOptions(putHandler);
-export const delete2_options = mergeOptions(deleteHandler);
+export const post2_options = normalizeOptions(postHandler);
+export const put2_options = normalizeOptions(putHandler);
+export const delete2_options = normalizeOptions(deleteHandler);
 
 export function get2(context) {
 	return render(context, page, {});

--- a/packages/run/src/vite/__tests__/fixtures/optional-types/__snapshots__/optional-types.expected.routes.md
+++ b/packages/run/src/vite/__tests__/fixtures/optional-types/__snapshots__/optional-types.expected.routes.md
@@ -22,15 +22,15 @@ import Page from "../../src/routes/aaa.$aId.(,bbb.$bId).(,ccc.$cId)/+page.marko"
 ```
 ### Handler
 ```js
-import { normalizeHandler, call, mergeOptions, render, stripResponseBody } from "virtual:marko-run/runtime/internal";
+import { normalizeHandler, call, normalizeOptions, render, stripResponseBody } from "virtual:marko-run/runtime/internal";
 import { mware2 } from "virtual:marko-run/__marko-run__middleware.js";
 import { GET } from "./src/routes/aaa.$aId.(,bbb.$bId).(,ccc.$cId)/+handler.ts";
 import page from "./dist/.marko-run/aaa.$.marko";
 
 const getHandler = normalizeHandler(GET, 'GET');
 
-export const get1_options = mergeOptions(mware2, getHandler);
-export const head1_options = mergeOptions(mware2);
+export const get1_options = normalizeOptions(mware2, getHandler);
+export const head1_options = normalizeOptions(mware2);
 
 export function get1(context) {
 	const __page = (data) => render(context, page, {}, data);
@@ -56,15 +56,15 @@ import Page from "../../src/routes/aaa.$aId.(,bbb.$bId).(,ccc.$cId)/+page.marko"
 ```
 ### Handler
 ```js
-import { normalizeHandler, call, mergeOptions, render, stripResponseBody } from "virtual:marko-run/runtime/internal";
+import { normalizeHandler, call, normalizeOptions, render, stripResponseBody } from "virtual:marko-run/runtime/internal";
 import { mware2 } from "virtual:marko-run/__marko-run__middleware.js";
 import { GET } from "./src/routes/aaa.$aId.(,bbb.$bId).(,ccc.$cId)/+handler.ts";
 import page from "./dist/.marko-run/aaa.$.bbb.$.marko";
 
 const getHandler = normalizeHandler(GET, 'GET');
 
-export const get2_options = mergeOptions(mware2, getHandler);
-export const head2_options = mergeOptions(mware2);
+export const get2_options = normalizeOptions(mware2, getHandler);
+export const head2_options = normalizeOptions(mware2);
 
 export function get2(context) {
 	const __page = (data) => render(context, page, {}, data);
@@ -90,15 +90,15 @@ import Page from "../../src/routes/aaa.$aId.(,bbb.$bId).(,ccc.$cId)/+page.marko"
 ```
 ### Handler
 ```js
-import { normalizeHandler, call, mergeOptions, render, stripResponseBody } from "virtual:marko-run/runtime/internal";
+import { normalizeHandler, call, normalizeOptions, render, stripResponseBody } from "virtual:marko-run/runtime/internal";
 import { mware2 } from "virtual:marko-run/__marko-run__middleware.js";
 import { GET } from "./src/routes/aaa.$aId.(,bbb.$bId).(,ccc.$cId)/+handler.ts";
 import page from "./dist/.marko-run/aaa.$.bbb.$.ccc.$.marko";
 
 const getHandler = normalizeHandler(GET, 'GET');
 
-export const get3_options = mergeOptions(mware2, getHandler);
-export const head3_options = mergeOptions(mware2);
+export const get3_options = normalizeOptions(mware2, getHandler);
+export const head3_options = normalizeOptions(mware2);
 
 export function get3(context) {
 	const __page = (data) => render(context, page, {}, data);
@@ -124,15 +124,15 @@ import Page from "../../src/routes/aaa.$aId.(,bbb.$bId).(,ccc.$cId)/+page.marko"
 ```
 ### Handler
 ```js
-import { normalizeHandler, call, mergeOptions, render, stripResponseBody } from "virtual:marko-run/runtime/internal";
+import { normalizeHandler, call, normalizeOptions, render, stripResponseBody } from "virtual:marko-run/runtime/internal";
 import { mware2 } from "virtual:marko-run/__marko-run__middleware.js";
 import { GET } from "./src/routes/aaa.$aId.(,bbb.$bId).(,ccc.$cId)/+handler.ts";
 import page from "./dist/.marko-run/aaa.$.ccc.$.marko";
 
 const getHandler = normalizeHandler(GET, 'GET');
 
-export const get4_options = mergeOptions(mware2, getHandler);
-export const head4_options = mergeOptions(mware2);
+export const get4_options = normalizeOptions(mware2, getHandler);
+export const head4_options = normalizeOptions(mware2);
 
 export function get4(context) {
 	const __page = (data) => render(context, page, {}, data);

--- a/packages/run/src/vite/codegen/index.ts
+++ b/packages/run/src/vite/codegen/index.ts
@@ -88,7 +88,7 @@ export function renderRouteEntry(route: Route, rootDir: string): string {
     runtimeImports.push("normalizeMeta");
   }
   if (handler || middleware.length) {
-    runtimeImports.push("call", "mergeOptions");
+    runtimeImports.push("call", "normalizeOptions");
   }
   if (page) {
     runtimeImports.push("render");
@@ -630,7 +630,7 @@ function writeRouteOptions(writer: Writer, route: Route, verb: HttpVerb): void {
   writer.write(`export const ${verb}${route.index}_options = `);
 
   if (route.middleware.length || hasHandler) {
-    writer.write(`mergeOptions(`);
+    writer.write(`normalizeOptions(`);
 
     let sep = "";
     for (const { id } of route.middleware) {


### PR DESCRIPTION
## Description

`@marko/run`: splits option merging from normalization. `mergeOptions` is now a pure, non-mutating merge of declared options (spread-copies instead of `Object.assign`, canonicalizes a bare validator to `{ validator }`), handlers store their raw declared options, and the new `normalizeOptions` — emitted by codegen for each route — applies defaults and validator normalization once per route. A key explicitly present with `undefined` (or another falsy value) now overrides the inherited option, while an absent key leaves it in place; the README documents this.

## Motivation and Context

Merging a route's options wrote into the shared `+middleware` options object (a module-scoped singleton), so one route's body validator and limits leaked into every later route. Handlers also stored normalized options with materialized defaults and an explicit `validator: undefined`, so a handler declaring only a size limit silently dropped the middleware's validator, contradicting the README's option-merging promise.

## Checklist:

- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
