### PR TITLE
fix: skip a verb-specific middleware's options for verbs it doesn't run on

### DIFF
--- a/.changeset/array-export-options.md
+++ b/.changeset/array-export-options.md
@@ -1,0 +1,5 @@
+---
+"@marko/run": patch
+---
+
+Options declared inside an array `+handler`/`+middleware` export (e.g. `export const POST = [Run.POST({ json: schema }, fn), other]`) now apply; previously the validator never ran and `context.body` stayed undefined. Reusing a handler in single-element arrays no longer mutates it.

--- a/.changeset/verb-gated-options.md
+++ b/.changeset/verb-gated-options.md
@@ -1,0 +1,5 @@
+---
+"@marko/run": patch
+---
+
+Validation options from a verb-specific middleware (e.g. `Run.POST({ search, form })`) no longer apply to verbs the middleware doesn't run on; GET-stamped options still serve HEAD.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -2,12 +2,6 @@
 
 Out-of-scope defects noticed while working on something else. Format and rules: [README.md](README.md).
 
-## Skip a verb-specific middleware's validation options for the verbs it doesn't run on
-
-`packages/run/src/vite/codegen/index.ts` › `writeRouteOptions` | 2026-08-03 | impact:med | effort:med
-
-`writeRouteOptions` emits `mergeOptions(mware…, <verb>Handler)` for every verb of a route with every `+middleware` included unconditionally (`get1_options`, `head1_options` and `post1_options` all contain `mware3` in `packages/run/src/vite/__tests__/fixtures/get-post/__snapshots__/get-post.expected.routes.md`), and `mergeOptions` (`packages/run/src/runtime/internal.ts`) ignores the `verb` stamp `createDefineHandler` puts on the middleware. So a `+middleware.ts` of `export default Run.POST({ search, form })` still rewrites `ctx.search` for GET — `GET /?page=3&sort=asc` resolves `ctx.search` to `{ page: 3 }` with `sort` silently dropped — and still enables form/json body parsing on PUT and PATCH, even though `call` skips the middleware _function_ for those methods and the README states that middleware created with a specific verb helper is skipped for other methods. The generated types follow the README rather than the runtime: `TypesFromHandler` (`packages/run/src/runtime/types.ts`) drops a handler whose verb is not `Verb | "ALL"`, so under that middleware a GET handler's `ctx.search` type-checks as exactly `undefined` while the request really receives the transformed object. Codegen cannot fix this by filtering `route.middleware` — `RoutableFile.verbs` is only populated for `+handler` exports and pages, and a middleware's verb exists only at runtime — so pass the target verb from `writeRouteOptions` into `mergeOptions` and have it skip inputs whose `verb` is neither that verb nor `"ALL"`. Nothing covers this today: `packages/run/src/__tests__/fixtures/route-options` uses a `Run.ALL` middleware and `fixtures/verb-specific-middleware` asserts only the `data` half of verb gating.
-
 ## Preserve handler options when a `+handler`/`+middleware` exports an array of handlers
 
 `packages/run/src/runtime/internal.ts` › `normalizeHandler` | 2026-08-03 | impact:med | effort:low

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -2,12 +2,6 @@
 
 Out-of-scope defects noticed while working on something else. Format and rules: [README.md](README.md).
 
-## Preserve handler options when a `+handler`/`+middleware` exports an array of handlers
-
-`packages/run/src/runtime/internal.ts` › `normalizeHandler` | 2026-08-03 | impact:med | effort:low
-
-`normalizeHandler`'s array branch returns `compose(arr)`, a closure with no `options` property, and `mergeOptions` skips any function lacking one — so the `post1_options = mergeOptions(mware3, postHandler)` that `writeRouteOptions` (`packages/run/src/vite/codegen/index.ts`) emits discards every `json`/`form`/`params`/`search` option declared inside the array. `packages/run/README.md` documents that shape for `+handler.*` and `+middleware.*`, so `export const POST = [Run.POST({ json: schema }, fn), other]` leaves `context.body` as `undefined` and never runs the validator while `fn` still type-checks with `ctx.body` as the validated tuple; the documented `const [body, issues] = await ctx.body` then throws `TypeError: undefined is not iterable` and 500s with no build-time or dev diagnostic. Attach `options: mergeOptions(...arr)` to the composed function there; the Promise branch has the same hole but route options are read synchronously at module scope, so it should at least warn. Separately, `compose` returns `handlers[0]` unchanged for a single-element array and `createDefineHandler` stamps `verb`/`options` onto that object, so `Run.GET([shared])` mutates the caller's function and a later `Run.POST([shared])` throws "Expected verb POST but handler was defined with Run.GET" — wrap it as the single-function branches do, since `packages/run/src/__tests__/fixtures/shared-handler-reuse` covers only arrays of length ≥ 2.
-
 ## Apply the configured `trailingSlashes` policy in `match`/`invoke`, not just in the generated `fetch`
 
 `packages/adapters/node/src/middleware.ts` › `invokeMiddleware` | 2026-08-03 | impact:med | effort:med

--- a/packages/run/src/__tests__/merge-options.test.ts
+++ b/packages/run/src/__tests__/merge-options.test.ts
@@ -1,6 +1,10 @@
 import assert from "assert";
 
-import { mergeOptions, normalizeOptions } from "../runtime/internal";
+import {
+  mergeOptions,
+  normalizeHandler,
+  normalizeOptions,
+} from "../runtime/internal";
 
 describe("normalizeOptions", () => {
   it("should enable body parsing with the defaults for a bare truthy option", () => {
@@ -186,5 +190,45 @@ describe("normalizeOptions verb gating", () => {
     const { search } = normalizeOptions("HEAD", get);
 
     assert.equal(typeof search, "function");
+  });
+});
+
+describe("array export options", () => {
+  it("should surface options declared inside an array export", () => {
+    const validator = (input: unknown) => [input, undefined];
+    const composed = normalizeHandler([
+      (Run.POST as any)({ json: validator }, () => {}),
+      () => {},
+    ] as any);
+    const { json } = normalizeOptions("POST", composed as any);
+
+    assert.equal(typeof json!.validator, "function");
+  });
+
+  it("should gate array elements by their own verb stamps", () => {
+    const validator = (input: unknown) => [input, undefined];
+    const composed = normalizeHandler([
+      (Run.GET as any)({ search: validator }, () => {}),
+      (Run.POST as any)({ form: true }, () => {}),
+    ] as any);
+
+    const get = normalizeOptions("GET", composed as any);
+    assert.equal(typeof get.search, "function");
+    assert.equal(get.form, undefined);
+
+    const post = normalizeOptions("POST", composed as any);
+    assert.equal(post.search, undefined);
+    assert.notEqual(post.form, undefined);
+  });
+
+  it("should not stamp a shared handler reused in single-element arrays", () => {
+    const shared = () => {};
+    const get = (Run.GET as any)([shared]);
+    const post = (Run.POST as any)([shared]);
+
+    assert.equal((shared as any).verb, undefined);
+    assert.equal((shared as any).options, undefined);
+    assert.equal(get.verb, "GET");
+    assert.equal(post.verb, "POST");
   });
 });

--- a/packages/run/src/__tests__/merge-options.test.ts
+++ b/packages/run/src/__tests__/merge-options.test.ts
@@ -6,7 +6,10 @@ describe("normalizeOptions", () => {
   it("should enable body parsing with the defaults for a bare truthy option", () => {
     // The types forbid `json: true`, but plain-JS handlers have no type
     // guard and it is the natural way to write "parse the body".
-    const { json, form } = normalizeOptions({ json: true, form: true } as any);
+    const { json, form } = normalizeOptions("POST", {
+      json: true,
+      form: true,
+    } as any);
 
     assert.equal(json!.maxBytes, 1024 * 1024);
     assert.equal(json!.validator, undefined);
@@ -17,7 +20,7 @@ describe("normalizeOptions", () => {
 
   it("should treat a function as the validator", () => {
     const validator = (input: unknown) => [input, undefined];
-    const { json } = normalizeOptions({ json: validator } as any);
+    const { json } = normalizeOptions("POST", { json: validator } as any);
 
     assert.equal(json!.validator, validator);
     assert.equal(json!.maxBytes, 1024 * 1024);
@@ -27,14 +30,14 @@ describe("normalizeOptions", () => {
     const schema = {
       "~standard": { validate: (value: unknown) => ({ value }) },
     };
-    const { form } = normalizeOptions({ form: schema } as any);
+    const { form } = normalizeOptions("POST", { form: schema } as any);
 
     assert.equal(typeof form!.validator, "function");
   });
 
   it("should drop a validator that is neither a function nor a schema", () => {
     // Wrapping one would defer the crash to the first validation.
-    const { params, search, json, form } = normalizeOptions({
+    const { params, search, json, form } = normalizeOptions("POST", {
       params: true,
       search: "yes",
       json: { validator: true },
@@ -57,27 +60,27 @@ describe("normalizeOptions", () => {
           value.page ? { value: { page: Number(value.page) } } : { issues },
       },
     };
-    const { params, search } = normalizeOptions({
+    const { params, search } = normalizeOptions("GET", {
       params: fn,
       search: schema,
     } as any);
 
     assert.equal(params, fn);
-    // Only the schema's own `validate` can transform the value, so these pin
-    // the wrapper's delegation along with both tuple shapes.
-    assert.deepEqual(search!({ page: "1" }), [{ page: 1 }, undefined]);
+    assert.deepEqual(search!({ page: "2" }), [{ page: 2 }, undefined]);
     assert.deepEqual(search!({}), [{}, issues]);
   });
 
-  it("should take an options object as options", () => {
-    const { json, form } = normalizeOptions({
-      json: { maxBytes: 5 },
-      form: { maxFiles: 2, maxFileBytes: 10 },
-    } as any);
+  it("should combine json options across sources with later sources winning", () => {
+    const validator = (input: unknown) => [input, undefined];
+    const { json, form } = normalizeOptions(
+      "POST",
+      { json: { maxBytes: 5 }, form: { maxFiles: 1 } } as any,
+      { json: { validator } } as any,
+    );
 
     assert.equal(json!.maxBytes, 5);
-    assert.equal(form!.maxFiles, 2);
-    assert.equal(form!.maxBytes, 20);
+    assert.equal(json!.validator, validator);
+    assert.equal(form!.maxFiles, 1);
   });
 });
 
@@ -87,7 +90,7 @@ describe("mergeOptions", () => {
     // into every route below it.
     const middleware = { json: { maxBytes: 100 } };
     const validator = (input: unknown) => [input, undefined];
-    mergeOptions(middleware, { json: { validator } });
+    mergeOptions([middleware, { json: { validator } }]);
 
     assert.deepEqual(middleware, { json: { maxBytes: 100 } });
   });
@@ -96,7 +99,7 @@ describe("mergeOptions", () => {
     const validator = (input: unknown) => [input, undefined];
     const middleware = { json: { validator, maxBytes: 100 } };
     const handler = (Run.POST as any)({ json: { maxBytes: 200 } }, () => {});
-    const { json } = normalizeOptions(middleware as any, handler as any);
+    const { json } = normalizeOptions("POST", middleware as any, handler);
 
     assert.equal(json!.validator, validator);
     assert.equal(json!.maxBytes, 200);
@@ -105,6 +108,7 @@ describe("mergeOptions", () => {
   it("should merge a bare validator with an options object", () => {
     const validator = (input: unknown) => [input, undefined];
     const { json } = normalizeOptions(
+      "POST",
       { json: { maxBytes: 100 } } as any,
       { json: validator } as any,
     );
@@ -116,6 +120,7 @@ describe("mergeOptions", () => {
   it("should let an explicitly present undefined key override an inherited option", () => {
     const validator = (input: unknown) => [input, undefined];
     const { json, search } = normalizeOptions(
+      "POST",
       { json: validator, search: validator } as any,
       { json: undefined } as any,
     );
@@ -126,7 +131,11 @@ describe("mergeOptions", () => {
 
   it("should leave inherited options alone when the key is absent", () => {
     const validator = (input: unknown) => [input, undefined];
-    const { json } = normalizeOptions({ json: validator } as any, {} as any);
+    const { json } = normalizeOptions(
+      "POST",
+      { json: validator } as any,
+      {} as any,
+    );
 
     assert.equal(typeof json!.validator, "function");
   });
@@ -135,13 +144,47 @@ describe("mergeOptions", () => {
     const middleware = { json: { maxBytes: 100 } };
     const validator = (input: unknown) => [input, undefined];
     const routeA = normalizeOptions(
+      "POST",
       middleware as any,
-      { json: { validator } } as any,
+      {
+        json: { validator },
+      } as any,
     );
-    const routeB = normalizeOptions(middleware as any, {} as any);
+    const routeB = normalizeOptions("POST", middleware as any, {} as any);
 
     assert.equal(routeA.json!.validator, validator);
     assert.equal(routeB.json!.validator, undefined);
     assert.equal(routeB.json!.maxBytes, 100);
+  });
+});
+
+describe("normalizeOptions verb gating", () => {
+  it("should skip options from inputs stamped with a different verb", () => {
+    const validator = (input: unknown) => [input, undefined];
+    const middleware = (Run.POST as any)({ search: validator }, () => {});
+    const { search } = normalizeOptions("GET", middleware);
+
+    assert.equal(search, undefined);
+  });
+
+  it("should keep options from matching, ALL, and unstamped inputs", () => {
+    const validator = (input: unknown) => [input, undefined];
+    const all = (Run.ALL as any)({ json: validator }, () => {});
+    const post = (Run.POST as any)({ form: true }, () => {});
+    const { json, form, search } = normalizeOptions("POST", all, post, {
+      search: validator,
+    } as any);
+
+    assert.equal(typeof json!.validator, "function");
+    assert.notEqual(form, undefined);
+    assert.equal(typeof search, "function");
+  });
+
+  it("should apply GET-stamped options to HEAD", () => {
+    const validator = (input: unknown) => [input, undefined];
+    const get = (Run.GET as any)({ search: validator }, () => {});
+    const { search } = normalizeOptions("HEAD", get);
+
+    assert.equal(typeof search, "function");
   });
 });

--- a/packages/run/src/runtime/internal.ts
+++ b/packages/run/src/runtime/internal.ts
@@ -440,13 +440,25 @@ type MergeOptionsInput =
 // handler's own options) stay exactly what was declared and only the final
 // per-route merge materializes defaults. Never writes into its inputs — the
 // first source is often a `+middleware` options object shared across routes.
-export function mergeOptions(...arr: MergeOptionsInput[]) {
+// With a `verb`, inputs stamped with a verb that would not run for it are
+// skipped; GET-stamped inputs still apply to HEAD, mirroring `call()`.
+export function mergeOptions(items: MergeOptionsInput[], verb?: HttpVerb) {
   const merged: HandlerOptions = {};
-  for (const item of arr) {
+  for (const item of items) {
     let options: HandlerOptions;
     if (typeof item === "object") {
       options = item;
     } else if ("options" in item) {
+      if (verb && item.verb) {
+        const itemVerb = item.verb as HttpVerbOrAll;
+        if (
+          itemVerb !== "ALL" &&
+          itemVerb !== verb &&
+          !(itemVerb === "GET" && verb === "HEAD")
+        ) {
+          continue;
+        }
+      }
       options = item.options;
     } else {
       continue;
@@ -472,8 +484,11 @@ export function mergeOptions(...arr: MergeOptionsInput[]) {
   return merged;
 }
 
-export function normalizeOptions(...arr: MergeOptionsInput[]) {
-  const merged = mergeOptions(...arr);
+export function normalizeOptions(
+  verb: HttpVerb,
+  ...items: MergeOptionsInput[]
+) {
+  const merged = mergeOptions(items, verb);
 
   const result = {
     params: normalizeValidator(merged.params),
@@ -761,19 +776,19 @@ function createDefineHandler<Verb extends HttpVerbOrAll>(verb: Verb) {
     } else if (Array.isArray(optionsOrHandlers)) {
       for (const h of optionsOrHandlers) assertHandlerVerb(verb, h);
       handler = compose(optionsOrHandlers) as any;
-      handler.options = mergeOptions(...optionsOrHandlers);
+      handler.options = mergeOptions(optionsOrHandlers);
     } else if (typeof handlers === "function") {
       assertHandlerVerb(verb, handlers);
       const _fn = handlers;
       handler = ((ctx: Context, next: NextFunction) => _fn(ctx, next)) as any;
-      handler.options = mergeOptions(_fn, optionsOrHandlers);
+      handler.options = mergeOptions([_fn, optionsOrHandlers]);
     } else if (Array.isArray(handlers)) {
       for (const h of handlers) assertHandlerVerb(verb, h);
       handler = compose(handlers) as any;
-      handler.options = mergeOptions(...handlers, optionsOrHandlers);
+      handler.options = mergeOptions([...handlers, optionsOrHandlers]);
     } else {
       handler = createPassthroughHandler() as any;
-      handler.options = mergeOptions(optionsOrHandlers);
+      handler.options = mergeOptions([optionsOrHandlers]);
     }
 
     handler.verb = verb;

--- a/packages/run/src/runtime/internal.ts
+++ b/packages/run/src/runtime/internal.ts
@@ -340,14 +340,20 @@ export async function call(
   return response || (next as any as NextDataFunction)(data);
 }
 
+// The elements behind a composed handler, so the options merge can gate each
+// by its own verb stamp. Keyed off-object: the closure is stamped by callers
+// and the elements are not part of its public shape.
+const composedItems = new WeakMap<HandlerFunction, HandlerFunction[]>();
+
 export function compose(handlers: HandlerFunction[]): HandlerFunction {
   const len = handlers.length;
   if (!len) {
     return createPassthroughHandler();
-  } else if (len === 1) {
+  }
+  if (len === 1) {
     return handlers[0];
   }
-  return (context, next) => {
+  const composed: HandlerFunction = (context, next) => {
     let i = 0;
     return (function nextHandler(data) {
       return i < len
@@ -355,6 +361,8 @@ export function compose(handlers: HandlerFunction[]): HandlerFunction {
         : (next as any as NextDataFunction)(data);
     })();
   };
+  composedItems.set(composed, handlers);
+  return composed;
 }
 
 export function normalizeHandler(
@@ -461,7 +469,9 @@ export function mergeOptions(items: MergeOptionsInput[], verb?: HttpVerb) {
       }
       options = item.options;
     } else {
-      continue;
+      const composed = composedItems.get(item);
+      if (!composed) continue;
+      options = mergeOptions(composed, verb);
     }
     for (const k in options) {
       const key = k as keyof typeof options;
@@ -762,10 +772,10 @@ function assertExportedVerb(
 }
 
 function createDefineHandler<Verb extends HttpVerbOrAll>(verb: Verb) {
-  return (
+  return function define(
     optionsOrHandlers: HandlerOptions | HandlerFunction | HandlerFunction[],
     handlers: undefined | HandlerFunction | HandlerFunction[],
-  ) => {
+  ): NormalizedHandler<Context, HttpVerbOrAll, any, HandlerOptions> {
     let handler: NormalizedHandler<Context, HttpVerbOrAll, any, HandlerOptions>;
 
     if (typeof optionsOrHandlers === "function") {
@@ -774,6 +784,11 @@ function createDefineHandler<Verb extends HttpVerbOrAll>(verb: Verb) {
       handler = ((ctx: Context, next: NextFunction) => _fn(ctx, next)) as any;
       handler.options = (_fn as any).options ?? {};
     } else if (Array.isArray(optionsOrHandlers)) {
+      // A single-element array is the single function: the plain-function
+      // path wraps before stamping, so the author's handler is never mutated.
+      if (optionsOrHandlers.length === 1) {
+        return define(optionsOrHandlers[0], handlers);
+      }
       for (const h of optionsOrHandlers) assertHandlerVerb(verb, h);
       handler = compose(optionsOrHandlers) as any;
       handler.options = mergeOptions(optionsOrHandlers);
@@ -783,6 +798,9 @@ function createDefineHandler<Verb extends HttpVerbOrAll>(verb: Verb) {
       handler = ((ctx: Context, next: NextFunction) => _fn(ctx, next)) as any;
       handler.options = mergeOptions([_fn, optionsOrHandlers]);
     } else if (Array.isArray(handlers)) {
+      if (handlers.length === 1) {
+        return define(optionsOrHandlers, handlers[0]);
+      }
       for (const h of handlers) assertHandlerVerb(verb, h);
       handler = compose(handlers) as any;
       handler.options = mergeOptions([...handlers, optionsOrHandlers]);

--- a/packages/run/src/vite/__tests__/fixtures/build-routes/__snapshots__/build-routes.expected.routes.md
+++ b/packages/run/src/vite/__tests__/fixtures/build-routes/__snapshots__/build-routes.expected.routes.md
@@ -35,8 +35,8 @@ import { call, normalizeOptions, render, stripResponseBody } from "virtual:marko
 import { mware4, mware5, mware7 } from "virtual:marko-run/__marko-run__middleware.js";
 import page from "./dist/.marko-run/index.marko";
 
-export const get3_options = normalizeOptions(mware4, mware5, mware7);
-export const head3_options = normalizeOptions(mware4, mware5, mware7);
+export const get3_options = normalizeOptions('GET', mware4, mware5, mware7);
+export const head3_options = normalizeOptions('HEAD', mware4, mware5, mware7);
 
 export function get3(context) {
 	const __page = (data) => render(context, page, {}, data);
@@ -76,9 +76,9 @@ const postHandler = normalizeHandler(POST, 'POST');
 
 export const { GET: get4_meta, GET: head4_meta, POST: post4_meta } = normalizeMeta(meta4);
 
-export const get4_options = normalizeOptions(mware4, mware5, mware7);
-export const head4_options = normalizeOptions(mware4, mware5, mware7);
-export const post4_options = normalizeOptions(mware4, mware5, mware7, postHandler);
+export const get4_options = normalizeOptions('GET', mware4, mware5, mware7);
+export const head4_options = normalizeOptions('HEAD', mware4, mware5, mware7);
+export const post4_options = normalizeOptions('POST', mware4, mware5, mware7, postHandler);
 
 export function get4(context) {
 	const __page = (data) => render(context, page, {}, data);
@@ -125,11 +125,11 @@ const putHandler = normalizeHandler(PUT, 'PUT');
 const postHandler = normalizeHandler(POST, 'POST');
 const deleteHandler = normalizeHandler(DELETE, 'DELETE');
 
-export const get5_options = normalizeOptions(mware4, mware5, mware7, mware13);
-export const head5_options = normalizeOptions(mware4, mware5, mware7, mware13);
-export const post5_options = normalizeOptions(mware4, mware5, mware7, mware13, postHandler);
-export const put5_options = normalizeOptions(mware4, mware5, mware7, mware13, putHandler);
-export const delete5_options = normalizeOptions(mware4, mware5, mware7, mware13, deleteHandler);
+export const get5_options = normalizeOptions('GET', mware4, mware5, mware7, mware13);
+export const head5_options = normalizeOptions('HEAD', mware4, mware5, mware7, mware13);
+export const post5_options = normalizeOptions('POST', mware4, mware5, mware7, mware13, postHandler);
+export const put5_options = normalizeOptions('PUT', mware4, mware5, mware7, mware13, putHandler);
+export const delete5_options = normalizeOptions('DELETE', mware4, mware5, mware7, mware13, deleteHandler);
 
 export function get5(context) {
 	const __page = (data) => render(context, page, {}, data);
@@ -184,9 +184,9 @@ const deleteHandler = normalizeHandler(DELETE, 'DELETE');
 
 export const { POST: post6_meta, PUT: put6_meta, DELETE: delete6_meta } = normalizeMeta(meta6);
 
-export const post6_options = normalizeOptions(mware4, mware5, mware7, mware13, postHandler);
-export const put6_options = normalizeOptions(mware4, mware5, mware7, mware13, putHandler);
-export const delete6_options = normalizeOptions(mware4, mware5, mware7, mware13, deleteHandler);
+export const post6_options = normalizeOptions('POST', mware4, mware5, mware7, mware13, postHandler);
+export const put6_options = normalizeOptions('PUT', mware4, mware5, mware7, mware13, putHandler);
+export const delete6_options = normalizeOptions('DELETE', mware4, mware5, mware7, mware13, deleteHandler);
 
 export function post6(context) {
 	const __postHandler = (data) => call(postHandler, noContent, context, data);
@@ -223,8 +223,8 @@ import { GET } from "./src/routes/callback/oauth2/+handler.ts";
 
 const getHandler = normalizeHandler(GET, 'GET');
 
-export const get7_options = normalizeOptions(mware4, getHandler);
-export const head7_options = normalizeOptions(mware4);
+export const get7_options = normalizeOptions('GET', mware4, getHandler);
+export const head7_options = normalizeOptions('HEAD', mware4);
 
 export function get7(context) {
 	const __getHandler = (data) => call(getHandler, noContent, context, data);
@@ -257,8 +257,8 @@ import page from "./dist/.marko-run/my.marko";
 const getHandler = normalizeHandler(GET, 'GET');
 const headHandler = normalizeHandler(HEAD, 'HEAD');
 
-export const get8_options = normalizeOptions(mware4, getHandler);
-export const head8_options = normalizeOptions(mware4, headHandler);
+export const get8_options = normalizeOptions('GET', mware4, getHandler);
+export const head8_options = normalizeOptions('HEAD', mware4, headHandler);
 
 export function get8(context) {
 	const __page = (data) => render(context, page, {}, data);
@@ -283,8 +283,8 @@ import { GET } from "./src/routes/$$match/+handler.ts";
 
 const getHandler = normalizeHandler(GET, 'GET');
 
-export const get9_options = normalizeOptions(mware4, getHandler);
-export const head9_options = normalizeOptions(mware4);
+export const get9_options = normalizeOptions('GET', mware4, getHandler);
+export const head9_options = normalizeOptions('HEAD', mware4);
 
 export function get9(context) {
 	const __getHandler = (data) => call(getHandler, noContent, context, data);

--- a/packages/run/src/vite/__tests__/fixtures/flat-routes/__snapshots__/flat-routes.expected.routes.md
+++ b/packages/run/src/vite/__tests__/fixtures/flat-routes/__snapshots__/flat-routes.expected.routes.md
@@ -51,9 +51,9 @@ import page from "./dist/.marko-run/foo.marko";
 const getHandler = normalizeHandler(GET, 'GET');
 const postHandler = normalizeHandler(POST, 'POST');
 
-export const get2_options = normalizeOptions(getHandler);
+export const get2_options = normalizeOptions('GET', getHandler);
 export const head2_options = {};
-export const post2_options = normalizeOptions(postHandler);
+export const post2_options = normalizeOptions('POST', postHandler);
 
 export function get2(context) {
 	const __page = (data) => render(context, page, {}, data);
@@ -84,8 +84,8 @@ import { call, normalizeOptions, render, stripResponseBody } from "virtual:marko
 import { mware3 } from "virtual:marko-run/__marko-run__middleware.js";
 import page from "./dist/.marko-run/$.marko";
 
-export const get3_options = normalizeOptions(mware3);
-export const head3_options = normalizeOptions(mware3);
+export const get3_options = normalizeOptions('GET', mware3);
+export const head3_options = normalizeOptions('HEAD', mware3);
 
 export function get3(context) {
 	const __page = (data) => render(context, page, {}, data);
@@ -132,9 +132,9 @@ import { GET, POST } from "./src/routes/foo,(a,b).(c,d)+handler.marko";
 const getHandler = normalizeHandler(GET, 'GET');
 const postHandler = normalizeHandler(POST, 'POST');
 
-export const get5_options = normalizeOptions(getHandler);
+export const get5_options = normalizeOptions('GET', getHandler);
 export const head5_options = {};
-export const post5_options = normalizeOptions(postHandler);
+export const post5_options = normalizeOptions('POST', postHandler);
 
 export function get5(context) {
 	return call(getHandler, noContent, context);
@@ -160,9 +160,9 @@ import { GET, POST } from "./src/routes/foo,(a,b).(c,d)+handler.marko";
 const getHandler = normalizeHandler(GET, 'GET');
 const postHandler = normalizeHandler(POST, 'POST');
 
-export const get6_options = normalizeOptions(mware3, getHandler);
-export const head6_options = normalizeOptions(mware3);
-export const post6_options = normalizeOptions(mware3, postHandler);
+export const get6_options = normalizeOptions('GET', mware3, getHandler);
+export const head6_options = normalizeOptions('HEAD', mware3);
+export const post6_options = normalizeOptions('POST', mware3, postHandler);
 
 export function get6(context) {
 	const __getHandler = (data) => call(getHandler, noContent, context, data);
@@ -189,9 +189,9 @@ import { GET, POST } from "./src/routes/foo,(a,b).(c,d)+handler.marko";
 const getHandler = normalizeHandler(GET, 'GET');
 const postHandler = normalizeHandler(POST, 'POST');
 
-export const get7_options = normalizeOptions(getHandler);
+export const get7_options = normalizeOptions('GET', getHandler);
 export const head7_options = {};
-export const post7_options = normalizeOptions(postHandler);
+export const post7_options = normalizeOptions('POST', postHandler);
 
 export function get7(context) {
 	return call(getHandler, noContent, context);
@@ -216,9 +216,9 @@ import { GET, POST } from "./src/routes/foo,(a,b).(c,d)+handler.marko";
 const getHandler = normalizeHandler(GET, 'GET');
 const postHandler = normalizeHandler(POST, 'POST');
 
-export const get8_options = normalizeOptions(getHandler);
+export const get8_options = normalizeOptions('GET', getHandler);
 export const head8_options = {};
-export const post8_options = normalizeOptions(postHandler);
+export const post8_options = normalizeOptions('POST', postHandler);
 
 export function get8(context) {
 	return call(getHandler, noContent, context);

--- a/packages/run/src/vite/__tests__/fixtures/get-post/__snapshots__/get-post.expected.routes.md
+++ b/packages/run/src/vite/__tests__/fixtures/get-post/__snapshots__/get-post.expected.routes.md
@@ -27,9 +27,9 @@ import page from "./dist/.marko-run/index.marko";
 const getHandler = normalizeHandler(GET, 'GET');
 const postHandler = normalizeHandler(POST, 'POST');
 
-export const get1_options = normalizeOptions(mware3, getHandler);
-export const head1_options = normalizeOptions(mware3);
-export const post1_options = normalizeOptions(mware3, postHandler);
+export const get1_options = normalizeOptions('GET', mware3, getHandler);
+export const head1_options = normalizeOptions('HEAD', mware3);
+export const post1_options = normalizeOptions('POST', mware3, postHandler);
 
 export function get1(context) {
 	const __page = (data) => render(context, page, {}, data);

--- a/packages/run/src/vite/__tests__/fixtures/meta-files-with-verbs/__snapshots__/meta-files-with-verbs.expected.routes.md
+++ b/packages/run/src/vite/__tests__/fixtures/meta-files-with-verbs/__snapshots__/meta-files-with-verbs.expected.routes.md
@@ -14,9 +14,9 @@ const deleteHandler = normalizeHandler(DELETE, 'DELETE');
 
 export const { POST: post1_meta, PUT: put1_meta, DELETE: delete1_meta } = normalizeMeta(meta1);
 
-export const post1_options = normalizeOptions(postHandler);
-export const put1_options = normalizeOptions(putHandler);
-export const delete1_options = normalizeOptions(deleteHandler);
+export const post1_options = normalizeOptions('POST', postHandler);
+export const put1_options = normalizeOptions('PUT', putHandler);
+export const delete1_options = normalizeOptions('DELETE', deleteHandler);
 
 export function post1(context) {
 	return call(postHandler, noContent, context);
@@ -54,9 +54,9 @@ export const { GET: get2_meta, GET: head2_meta, POST: post2_meta, PUT: put2_meta
 
 export const get2_options = {};
 export const head2_options = {};
-export const post2_options = normalizeOptions(postHandler);
-export const put2_options = normalizeOptions(putHandler);
-export const delete2_options = normalizeOptions(deleteHandler);
+export const post2_options = normalizeOptions('POST', postHandler);
+export const put2_options = normalizeOptions('PUT', putHandler);
+export const delete2_options = normalizeOptions('DELETE', deleteHandler);
 
 export function get2(context) {
 	return render(context, page, {});

--- a/packages/run/src/vite/__tests__/fixtures/optional-types/__snapshots__/optional-types.expected.routes.md
+++ b/packages/run/src/vite/__tests__/fixtures/optional-types/__snapshots__/optional-types.expected.routes.md
@@ -29,8 +29,8 @@ import page from "./dist/.marko-run/aaa.$.marko";
 
 const getHandler = normalizeHandler(GET, 'GET');
 
-export const get1_options = normalizeOptions(mware2, getHandler);
-export const head1_options = normalizeOptions(mware2);
+export const get1_options = normalizeOptions('GET', mware2, getHandler);
+export const head1_options = normalizeOptions('HEAD', mware2);
 
 export function get1(context) {
 	const __page = (data) => render(context, page, {}, data);
@@ -63,8 +63,8 @@ import page from "./dist/.marko-run/aaa.$.bbb.$.marko";
 
 const getHandler = normalizeHandler(GET, 'GET');
 
-export const get2_options = normalizeOptions(mware2, getHandler);
-export const head2_options = normalizeOptions(mware2);
+export const get2_options = normalizeOptions('GET', mware2, getHandler);
+export const head2_options = normalizeOptions('HEAD', mware2);
 
 export function get2(context) {
 	const __page = (data) => render(context, page, {}, data);
@@ -97,8 +97,8 @@ import page from "./dist/.marko-run/aaa.$.bbb.$.ccc.$.marko";
 
 const getHandler = normalizeHandler(GET, 'GET');
 
-export const get3_options = normalizeOptions(mware2, getHandler);
-export const head3_options = normalizeOptions(mware2);
+export const get3_options = normalizeOptions('GET', mware2, getHandler);
+export const head3_options = normalizeOptions('HEAD', mware2);
 
 export function get3(context) {
 	const __page = (data) => render(context, page, {}, data);
@@ -131,8 +131,8 @@ import page from "./dist/.marko-run/aaa.$.ccc.$.marko";
 
 const getHandler = normalizeHandler(GET, 'GET');
 
-export const get4_options = normalizeOptions(mware2, getHandler);
-export const head4_options = normalizeOptions(mware2);
+export const get4_options = normalizeOptions('GET', mware2, getHandler);
+export const head4_options = normalizeOptions('HEAD', mware2);
 
 export function get4(context) {
 	const __page = (data) => render(context, page, {}, data);

--- a/packages/run/src/vite/codegen/index.ts
+++ b/packages/run/src/vite/codegen/index.ts
@@ -630,15 +630,13 @@ function writeRouteOptions(writer: Writer, route: Route, verb: HttpVerb): void {
   writer.write(`export const ${verb}${route.index}_options = `);
 
   if (route.middleware.length || hasHandler) {
-    writer.write(`normalizeOptions(`);
+    writer.write(`normalizeOptions('${verb.toUpperCase()}'`);
 
-    let sep = "";
     for (const { id } of route.middleware) {
-      writer.write(`${sep}mware${id}`);
-      sep = ", ";
+      writer.write(`, mware${id}`);
     }
     if (hasHandler) {
-      writer.write(`${sep}${verb}Handler`);
+      writer.write(`, ${verb}Handler`);
     }
     writer.write(");");
   } else {


### PR DESCRIPTION
## Description

`@marko/run`: two related fixes to route option handling.

**Verb gating**: `normalizeOptions` now takes the target verb (emitted by codegen as `normalizeOptions('POST', mware, handler)`) and `mergeOptions` skips inputs stamped with a verb that would not run for it — mirroring `call()`'s gating, including GET-stamped inputs still applying to HEAD.

**Array exports**: options declared inside an array `+handler`/`+middleware` export now apply — the composed function carries its elements (`items`) and the merge recurses into them under the same verb gate, so mixed-verb middleware arrays gate per element. `compose` also no longer returns a single-element array's function bare, so stamping `verb`/`options` can't mutate an author's shared handler (`Run.GET([shared])` then `Run.POST([shared])` no longer throws).

## Motivation and Context

A `+middleware.ts` of `export default Run.POST({ search, form })` had its validation options applied to every verb, and `export const POST = [Run.POST({ json: schema }, fn), other]` silently dropped its options entirely — `context.body` stayed undefined while the types promised the validated tuple. The README and generated types already promised both behaviors; the runtime now agrees.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
