### PR TITLE
fix: break the dev import cycle when app code imports @marko/run/router

### DIFF
--- a/.changeset/dev-router-import-cycle.md
+++ b/.changeset/dev-router-import-cycle.md
@@ -1,0 +1,5 @@
+---
+"@marko/run": patch
+---
+
+Fix intermittent dev-server 500s when app code reachable from middleware imports `@marko/run/router`.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -176,12 +176,6 @@ If `vite.config.ts` imports project source (e.g. to start a sidecar server from 
 
 `pnpm test` fails on `main` with one snapshot mismatch. `packages/run/src/vite/utils/agent-fix-guide.ts` › `appendAgentFixGuide` appends "Fix guide: READ <path>/cheatsheet.md before writing a fix." to route-conflict errors, but this fixture's committed snapshot predates that change and still holds the untagged message, so the rendered error page differs by those two lines. Re-verify: `pnpm test` on a clean `main`, "Duplicate routes for path /$" is the only failure. Fix with `pnpm run test:update` and review the diff for any other fixture that renders a tagged error.
 
-## Break the generated router's import cycle so `@marko/run/router` imports don't race middleware initialization
-
-`packages/run/src/vite/codegen/index.ts` › `renderRouter` | 2026-08-13 | impact:high | effort:med
-
-Any app module that imports `@marko/run/router` and is itself reachable from a `+middleware`/`+handler` file creates a genuine ES module cycle in dev, and its evaluation order is not stable: generated router → route entry (`__marko-run__index.js`) → `__marko-run__middleware.js` → `+middleware.ts` → app helper → `@marko/run/router` → back to the generated router. When evaluation happens to enter at the middleware module rather than the router, the route entry runs `normalizeOptions('GET', mware1)` while `mware1` is still uninitialized, and `mergeOptions` (`packages/run/src/runtime/internal.ts`) throws `TypeError: Cannot use 'in' operator to search for 'options' in undefined` — the request 500s with an error overlay instead of rendering. The `import-router` fixture exercises exactly this shape and fails ~80% of runs on a clean `main` (measured 8/10 with the Vite cache cleared before each run; the ~20% pass is why it reads as an intermittent flake rather than a broken feature). `packages/run/src/runtime/router.ts` already defers to `globalThis.__marko_run__` at call time, so the fix is to stop having the plugin alias `@marko/run/router` onto the generated router module in dev and let it keep resolving to that lazy shim — the generated router already assigns `globalThis.__marko_run__` at module top, so nothing needs the direct binding. Re-verify: `rm -rf packages/run/node_modules/.vite && pnpm test --grep import-router`, repeated — dev fails most runs, preview always passes.
-
 ## Fix the flaky `dev-delete-route` dev test
 
 `packages/run/src/__tests__/fixtures/dev-delete-route/test.config.ts` › `restoreThePage` | 2026-08-13 | impact:med | effort:med

--- a/packages/run/src/vite/plugin.ts
+++ b/packages/run/src/vite/plugin.ts
@@ -699,7 +699,8 @@ export default function markoRun(opts: Options = {}): Plugin[] {
       },
       async resolveId(importee, importer) {
         let virtualFilePath: string | undefined;
-        const importerIsDevEntry =
+        const isDevEntry =
+          !isBuild &&
           !!importer &&
           (importer === devEntryFile ||
             normalizePath(importer) === devEntryFilePosix);
@@ -708,7 +709,7 @@ export default function markoRun(opts: Options = {}): Plugin[] {
           // In dev, module imports get the runtime facade, which defers to
           // the __marko_run__ global so app code reachable from middleware
           // can't create an evaluation cycle with the generated router.
-          if (isBuild || !importer || importerIsDevEntry) {
+          if (isBuild || !importer || isDevEntry) {
             return normalizePath(path.resolve(root, ROUTER_FILENAME));
           }
           return await this.resolve(
@@ -727,8 +728,7 @@ export default function markoRun(opts: Options = {}): Plugin[] {
           virtualFilePath = importee.slice(virtualFilePrefix.length + 1);
           importee = path.resolve(root, virtualFilePath);
         } else if (
-          !isBuild &&
-          importerIsDevEntry &&
+          isDevEntry &&
           importee.startsWith(`/${markoRunFilePrefix}`)
         ) {
           importee = path.resolve(root, "." + importee);

--- a/packages/run/src/vite/plugin.ts
+++ b/packages/run/src/vite/plugin.ts
@@ -704,7 +704,12 @@ export default function markoRun(opts: Options = {}): Plugin[] {
           // In dev, module imports get the runtime facade, which defers to
           // the __marko_run__ global so app code reachable from middleware
           // can't create an evaluation cycle with the generated router.
-          if (!isBuild && importer && !importer.endsWith(".html")) {
+          if (
+            !isBuild &&
+            importer &&
+            importer !== devEntryFile &&
+            normalizePath(importer) !== devEntryFilePosix
+          ) {
             return await this.resolve(
               path.resolve(__dirname, "../runtime/router"),
               importer,

--- a/packages/run/src/vite/plugin.ts
+++ b/packages/run/src/vite/plugin.ts
@@ -67,6 +67,7 @@ const PLUGIN_NAME_PREFIX = "marko-run-vite";
 const CLIENT_OUT_DIR = "public";
 const MIDDLEWARE_FILENAME = `${markoRunFilePrefix}middleware.js`;
 const ROUTER_FILENAME = `${markoRunFilePrefix}router.js`;
+const ROUTER_SHIM_FILENAME = `${markoRunFilePrefix}router-shim.js`;
 
 export const defaultPort = Number(process.env.PORT || 3000);
 
@@ -250,6 +251,12 @@ export default function markoRun(opts: Options = {}): Plugin[] {
         virtualFiles.set(path.posix.join(root, MIDDLEWARE_FILENAME), "");
       }
       virtualFiles.set(path.posix.join(root, ROUTER_FILENAME), "");
+      if (!isBuild) {
+        virtualFiles.set(
+          path.posix.join(root, ROUTER_SHIM_FILENAME),
+          renderRouterShim(path.posix.join(root, ROUTER_FILENAME)),
+        );
+      }
 
       for (const externalRoute of externalRoutes) {
         for (const { entryFile } of externalRoute.routes) {
@@ -701,20 +708,14 @@ export default function markoRun(opts: Options = {}): Plugin[] {
         let virtualFilePath: string | undefined;
 
         if (importee === "@marko/run/router") {
-          // In dev, only entry loads get the generated router; app imports
-          // keep the lazy runtime shim so a module reachable from middleware
+          // In dev, module imports get a shim that loads the generated
+          // router dynamically, so app code reachable from middleware
           // can't create an evaluation cycle with the router.
-          if (
-            isBuild ||
-            !importer ||
-            importer.endsWith(".html") ||
-            importer === devEntryFile ||
-            normalizePath(importer) === devEntryFilePosix ||
-            normalizePath(importer).endsWith("/adapter/default-entry.mjs")
-          ) {
-            return normalizePath(path.resolve(root, ROUTER_FILENAME));
-          }
-          return;
+          const filename =
+            !isBuild && importer && !importer.endsWith(".html")
+              ? ROUTER_SHIM_FILENAME
+              : ROUTER_FILENAME;
+          return normalizePath(path.resolve(root, filename));
         } else if (
           importee.endsWith(".marko") &&
           importee.includes(relativeEntryFilesDirPosix)
@@ -1053,4 +1054,23 @@ function getImporters(
     }
   }
   return seen;
+}
+
+function renderRouterShim(routerId: string): string {
+  const id = JSON.stringify(routerId);
+  return `let loading;
+const load = () => globalThis.__marko_run__ || (loading ??= import(${id}));
+load();
+export async function fetch(request, platform) {
+  await load();
+  return globalThis.__marko_run__.fetch(request, platform);
+}
+export async function invoke(route, request, platform, url) {
+  await load();
+  return globalThis.__marko_run__.invoke(route, request, platform, url);
+}
+export function match(method, pathname) {
+  return globalThis.__marko_run__.match(method, pathname);
+}
+`;
 }

--- a/packages/run/src/vite/plugin.ts
+++ b/packages/run/src/vite/plugin.ts
@@ -67,7 +67,6 @@ const PLUGIN_NAME_PREFIX = "marko-run-vite";
 const CLIENT_OUT_DIR = "public";
 const MIDDLEWARE_FILENAME = `${markoRunFilePrefix}middleware.js`;
 const ROUTER_FILENAME = `${markoRunFilePrefix}router.js`;
-const ROUTER_SHIM_FILENAME = `${markoRunFilePrefix}router-shim.js`;
 
 export const defaultPort = Number(process.env.PORT || 3000);
 
@@ -251,12 +250,6 @@ export default function markoRun(opts: Options = {}): Plugin[] {
         virtualFiles.set(path.posix.join(root, MIDDLEWARE_FILENAME), "");
       }
       virtualFiles.set(path.posix.join(root, ROUTER_FILENAME), "");
-      if (!isBuild) {
-        virtualFiles.set(
-          path.posix.join(root, ROUTER_SHIM_FILENAME),
-          renderRouterShim(path.posix.join(root, ROUTER_FILENAME)),
-        );
-      }
 
       for (const externalRoute of externalRoutes) {
         for (const { entryFile } of externalRoute.routes) {
@@ -708,14 +701,17 @@ export default function markoRun(opts: Options = {}): Plugin[] {
         let virtualFilePath: string | undefined;
 
         if (importee === "@marko/run/router") {
-          // In dev, module imports get a shim that loads the generated
-          // router dynamically, so app code reachable from middleware
-          // can't create an evaluation cycle with the router.
-          const filename =
-            !isBuild && importer && !importer.endsWith(".html")
-              ? ROUTER_SHIM_FILENAME
-              : ROUTER_FILENAME;
-          return normalizePath(path.resolve(root, filename));
+          // In dev, module imports get the runtime facade, which defers to
+          // the __marko_run__ global so app code reachable from middleware
+          // can't create an evaluation cycle with the generated router.
+          if (!isBuild && importer && !importer.endsWith(".html")) {
+            return await this.resolve(
+              path.resolve(__dirname, "../runtime/router"),
+              importer,
+              { skipSelf: true },
+            );
+          }
+          return normalizePath(path.resolve(root, ROUTER_FILENAME));
         } else if (
           importee.endsWith(".marko") &&
           importee.includes(relativeEntryFilesDirPosix)
@@ -1054,23 +1050,4 @@ function getImporters(
     }
   }
   return seen;
-}
-
-function renderRouterShim(routerId: string): string {
-  const id = JSON.stringify(routerId);
-  return `let loading;
-const load = () => globalThis.__marko_run__ || (loading ??= import(${id}));
-load();
-export async function fetch(request, platform) {
-  await load();
-  return globalThis.__marko_run__.fetch(request, platform);
-}
-export async function invoke(route, request, platform, url) {
-  await load();
-  return globalThis.__marko_run__.invoke(route, request, platform, url);
-}
-export function match(method, pathname) {
-  return globalThis.__marko_run__.match(method, pathname);
-}
-`;
 }

--- a/packages/run/src/vite/plugin.ts
+++ b/packages/run/src/vite/plugin.ts
@@ -701,7 +701,20 @@ export default function markoRun(opts: Options = {}): Plugin[] {
         let virtualFilePath: string | undefined;
 
         if (importee === "@marko/run/router") {
-          return normalizePath(path.resolve(root, ROUTER_FILENAME));
+          // In dev, only entry loads get the generated router; app imports
+          // keep the lazy runtime shim so a module reachable from middleware
+          // can't create an evaluation cycle with the router.
+          if (
+            isBuild ||
+            !importer ||
+            importer.endsWith(".html") ||
+            importer === devEntryFile ||
+            normalizePath(importer) === devEntryFilePosix ||
+            normalizePath(importer).endsWith("/adapter/default-entry.mjs")
+          ) {
+            return normalizePath(path.resolve(root, ROUTER_FILENAME));
+          }
+          return;
         } else if (
           importee.endsWith(".marko") &&
           importee.includes(relativeEntryFilesDirPosix)

--- a/packages/run/src/vite/plugin.ts
+++ b/packages/run/src/vite/plugin.ts
@@ -699,24 +699,23 @@ export default function markoRun(opts: Options = {}): Plugin[] {
       },
       async resolveId(importee, importer) {
         let virtualFilePath: string | undefined;
+        const importerIsDevEntry =
+          !!importer &&
+          (importer === devEntryFile ||
+            normalizePath(importer) === devEntryFilePosix);
 
         if (importee === "@marko/run/router") {
           // In dev, module imports get the runtime facade, which defers to
           // the __marko_run__ global so app code reachable from middleware
           // can't create an evaluation cycle with the generated router.
-          if (
-            !isBuild &&
-            importer &&
-            importer !== devEntryFile &&
-            normalizePath(importer) !== devEntryFilePosix
-          ) {
-            return await this.resolve(
-              path.resolve(__dirname, "../runtime/router"),
-              importer,
-              { skipSelf: true },
-            );
+          if (isBuild || !importer || importerIsDevEntry) {
+            return normalizePath(path.resolve(root, ROUTER_FILENAME));
           }
-          return normalizePath(path.resolve(root, ROUTER_FILENAME));
+          return await this.resolve(
+            path.resolve(__dirname, "../runtime/router"),
+            importer,
+            { skipSelf: true },
+          );
         } else if (
           importee.endsWith(".marko") &&
           importee.includes(relativeEntryFilesDirPosix)
@@ -729,9 +728,7 @@ export default function markoRun(opts: Options = {}): Plugin[] {
           importee = path.resolve(root, virtualFilePath);
         } else if (
           !isBuild &&
-          importer &&
-          (importer === devEntryFile ||
-            normalizePath(importer) === devEntryFilePosix) &&
+          importerIsDevEntry &&
           importee.startsWith(`/${markoRunFilePrefix}`)
         ) {
           importee = path.resolve(root, "." + importee);


### PR DESCRIPTION
In dev, the plugin aliased every import of `@marko/run/router` onto the generated router. App code reachable from a `+middleware`/`+handler` that imported it formed an ES module cycle with an unstable evaluation order — route entries could read middleware bindings before initialization and 500 (the `import-router` fixture failed ~80% of runs).

Module imports now resolve to the runtime facade (`src/runtime/router.ts`), which always defers to the `__marko_run__` global at call time, so no static cycle exists. Entry loads (`ssrLoadModule`) and builds keep resolving to the generated router directly.