### PR TITLE
fix: invalidate a restored route's entry modules when routes rebuild

### DIFF
--- a/.changeset/dev-restore-route-stale-entry.md
+++ b/.changeset/dev-restore-route-stale-entry.md
@@ -1,0 +1,5 @@
+---
+"@marko/run": patch
+---
+
+Fix restored route files intermittently 500ing in dev until the server restarts.

--- a/.changeset/dev-restore-route-stale-entry.md
+++ b/.changeset/dev-restore-route-stale-entry.md
@@ -2,4 +2,4 @@
 "@marko/run": patch
 ---
 
-Fix restored route files intermittently 500ing in dev until the server restarts.
+Fix restored route files intermittently returning HTTP 500 responses in dev until the server restarts.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -169,15 +169,3 @@ Dev runs Vite in middleware mode behind marko-run's own listener (`devServer.mid
 `packages/run/src/vite/plugin.ts` › `virtualFiles` | 2026-08-10 | impact:med | effort:med
 
 If `vite.config.ts` imports project source (e.g. to start a sidecar server from `configureServer`), editing any file in that import graph makes Vite restart in place — and after that restart every route answers 404 until the whole `marko-run dev` process is killed and restarted. Observed repeatedly in a real app; the workaround was spawning the sidecar as a child process (`spawn(process.execPath, [entry])`) so the config graph never touches server code, plus explicit `.ts` extensions to keep imports out of the graph. Suspect the `virtualFiles` map / route-walker state is not rebuilt on Vite's in-place restart path the way it is on first boot. Re-verify: a `marko-run dev` app whose `vite.config.ts` imports any file under `src/`; touch that file, wait for Vite's restart log, then curl any route — 404 until process restart.
-
-## Regenerate the `error-invalid-routes` dev snapshot for the appended agent fix guide
-
-`packages/run/src/__tests__/fixtures/error-invalid-routes/__snapshots__/dev.expected.md` › `error-invalid-routes` | 2026-08-11 | impact:med | effort:low
-
-`pnpm test` fails on `main` with one snapshot mismatch. `packages/run/src/vite/utils/agent-fix-guide.ts` › `appendAgentFixGuide` appends "Fix guide: READ <path>/cheatsheet.md before writing a fix." to route-conflict errors, but this fixture's committed snapshot predates that change and still holds the untagged message, so the rendered error page differs by those two lines. Re-verify: `pnpm test` on a clean `main`, "Duplicate routes for path /$" is the only failure. Fix with `pnpm run test:update` and review the diff for any other fixture that renders a tagged error.
-
-## Fix the flaky `dev-delete-route` dev test
-
-`packages/run/src/__tests__/fixtures/dev-delete-route/test.config.ts` › `restoreThePage` | 2026-08-13 | impact:med | effort:med
-
-`pnpm test --grep dev-delete-route` fails on a clean `main` with `Error: Timed out waiting for restored page to serve its content` from the `until` helper, after the fixture deletes a route file and writes it back. Measured 3/3 failures on unmodified `main` with the Vite cache cleared before each run, so it is not purely load-dependent, though it does pass occasionally on other trees — the route-restore HMR path appears to need longer than the fixture's timeout to re-register the deleted route, or never re-registers it without a further trigger. This is the second dev-server test that fails on `main` for reasons unrelated to any change under review, which trains contributors to ignore `pnpm test` failures. Either raise the wait bound if this is genuinely slow, or treat a never-restoring route as the real defect and fix the watcher path.

--- a/packages/run/src/__tests__/fixtures/error-invalid-routes/__snapshots__/dev.expected.md
+++ b/packages/run/src/__tests__/fixtures/error-invalid-routes/__snapshots__/dev.expected.md
@@ -10,8 +10,6 @@
     
 <h2>
   Duplicate routes for path /$ were defined. A route established by: "/src/routes/$bar+page.marko" collides with "/src/routes/$foo+page.marko"
-
-Fix guide: READ ../../../../cheatsheet.md before writing a fix.
 </h2>
 
     

--- a/packages/run/src/__tests__/fixtures/error-invalid-routes/__snapshots__/dev.expected.md
+++ b/packages/run/src/__tests__/fixtures/error-invalid-routes/__snapshots__/dev.expected.md
@@ -10,6 +10,8 @@
     
 <h2>
   Duplicate routes for path /$ were defined. A route established by: "/src/routes/$bar+page.marko" collides with "/src/routes/$foo+page.marko"
+
+Fix guide: READ ../../../../cheatsheet.md before writing a fix.
 </h2>
 
     

--- a/packages/run/src/__tests__/main.test.ts
+++ b/packages/run/src/__tests__/main.test.ts
@@ -9,6 +9,7 @@ import { fileURLToPath } from "url";
 
 import * as cli from "../cli/commands";
 import type { Options } from "../vite";
+import { AGENT_ENV_VARS } from "../vite/utils/agent-fix-guide";
 import { SpawnedServer, waitForServer } from "../vite/utils/server";
 import { BrowserPage } from "./utils/browser";
 
@@ -36,6 +37,11 @@ let page: BrowserPage;
 
 before(() => {
   process.env.TRUST_PROXY = "1";
+  // Fixture output must not depend on the terminal driving the suite: the
+  // agent-gated fix guide would otherwise leak into rendered-error snapshots.
+  for (const key of AGENT_ENV_VARS) {
+    delete process.env[key];
+  }
 });
 
 async function getHTML(settle = true) {

--- a/packages/run/src/vite/__tests__/agent-fix-guide.test.ts
+++ b/packages/run/src/vite/__tests__/agent-fix-guide.test.ts
@@ -1,18 +1,9 @@
 import assert from "assert";
 
 import appendAgentFixGuide, {
+  AGENT_ENV_VARS,
   agentRouteFixGuide,
 } from "../utils/agent-fix-guide";
-
-const AGENT_ENV_VARS = [
-  "CLAUDECODE",
-  "CLAUDE_CODE",
-  "CURSOR_AGENT",
-  "GEMINI_CLI",
-  "CODEX_SANDBOX",
-  "CODEX_THREAD_ID",
-  "AI_AGENT",
-];
 
 describe("agent-fix-guide", () => {
   let saved: Record<string, string | undefined>;

--- a/packages/run/src/vite/plugin.ts
+++ b/packages/run/src/vite/plugin.ts
@@ -211,8 +211,7 @@ export default function markoRun(opts: Options = {}): Plugin[] {
       try {
         let built: BuiltRoutes | undefined;
         if (fs.existsSync(resolvedRoutesDir)) {
-          // The walk has no shared side effects, so a build superseded
-          // mid-walk just walks again; after the loop commits exactly once.
+          // A superseded walk reruns, so it must not touch shared state.
           let version: number;
           do {
             version = buildVirtualFilesVersion;
@@ -691,8 +690,8 @@ export default function markoRun(opts: Options = {}): Plugin[] {
                     devServer.watcher.emit("change", file);
                   }
                 } else {
-                  // Rebuild before invalidating: a restored route's entry must
-                  // be evicted too, and only the fresh map knows its key.
+                  // Rebuild before emitting: a restored route's entry must be
+                  // evicted too, and only the fresh map knows its key.
                   try {
                     await buildVirtualFiles();
                   } catch {

--- a/packages/run/src/vite/plugin.ts
+++ b/packages/run/src/vite/plugin.ts
@@ -643,6 +643,7 @@ export default function markoRun(opts: Options = {}): Plugin[] {
                     routableFileType === RoutableFileTypes.Middleware ||
                     filename === runtimeInclude))
               ) {
+                const staleFiles = new Set(virtualFiles.keys());
                 buildVirtualFilesResult = undefined;
                 renderVirtualFilesResult = undefined;
                 routeMarkoApiCache = undefined;
@@ -659,7 +660,13 @@ export default function markoRun(opts: Options = {}): Plugin[] {
                     devServer.watcher.emit("change", file);
                   }
                 } else {
+                  // Rebuild before invalidating: a restored route's entry must
+                  // be evicted too, and only the fresh map knows its key.
+                  await buildVirtualFiles();
                   for (const file of virtualFiles.keys()) {
+                    staleFiles.add(file);
+                  }
+                  for (const file of staleFiles) {
                     if (!file.endsWith(".marko")) {
                       devServer.watcher.emit("change", file);
                     }

--- a/packages/run/src/vite/plugin.ts
+++ b/packages/run/src/vite/plugin.ts
@@ -191,82 +191,102 @@ export default function markoRun(opts: Options = {}): Plugin[] {
   }
 
   let buildVirtualFilesResult: Promise<BuiltRoutes> | undefined;
+  let buildVirtualFilesQueue: Promise<unknown> = Promise.resolve();
   function buildVirtualFiles() {
-    return (buildVirtualFilesResult ??= (async () => {
-      virtualFiles.clear();
-      if (fs.existsSync(resolvedRoutesDir)) {
-        routes = await buildRoutes(
-          {
-            walker: createFSWalker(resolvedRoutesDir),
-          },
-          entryFilesDir,
-        );
+    if (!buildVirtualFilesResult) {
+      // Serialized: a rebuild requested while one is in flight waits for it,
+      // so two walks never interleave their commits into the shared state.
+      const build = buildVirtualFilesQueue
+        .then(walkRoutes, walkRoutes)
+        .then((built) => {
+          commitVirtualFiles(built);
+          return built;
+        });
+      buildVirtualFilesQueue = build;
+      buildVirtualFilesResult = build.catch((err) => {
+        // Point coding agents at the cheat sheet on route-build errors,
+        // whichever plugin hook triggered the build.
+        throw appendAgentFixGuide(err);
+      });
+    }
+    return buildVirtualFilesResult;
+  }
 
-        if (
-          !isBuild &&
-          !routes.list.length &&
-          !Object.keys(routes.special).length
-        ) {
-          console.warn(`No routes found in ${resolvedRoutesDir}`);
-        }
-      } else {
-        routes = {
-          list: [],
-          special: {},
-          middleware: [],
-        };
+  async function walkRoutes(): Promise<BuiltRoutes> {
+    if (fs.existsSync(resolvedRoutesDir)) {
+      const built = await buildRoutes(
+        {
+          walker: createFSWalker(resolvedRoutesDir),
+        },
+        entryFilesDir,
+      );
 
-        if (!isBuild) {
-          console.warn(`Routes directory ${resolvedRoutesDir} does not exist`);
-        }
+      if (
+        !isBuild &&
+        !built.list.length &&
+        !Object.keys(built.special).length
+      ) {
+        console.warn(`No routes found in ${resolvedRoutesDir}`);
       }
 
-      entryTemplates = new Set();
-      entryTemplateImporters = new Set();
+      return built;
+    }
 
-      for (const route of routes.list) {
-        if (route.templateFilePath) {
-          entryTemplates.add(normalizePath(route.templateFilePath));
-        }
-        for (const middleware of route.middleware) {
-          entryTemplateImporters.add(normalizePath(middleware.filePath));
-        }
-        if (route.handler) {
-          entryTemplateImporters.add(normalizePath(route.handler.filePath));
-        }
+    if (!isBuild) {
+      console.warn(`Routes directory ${resolvedRoutesDir} does not exist`);
+    }
 
-        virtualFiles.set(
-          path.posix.join(root, getRouteVirtualFileName(route)),
-          "",
-        );
+    return {
+      list: [],
+      special: {},
+      middleware: [],
+    };
+  }
+
+  // Synchronous, so the shared state swaps atomically: no awaits between the
+  // clear and the repopulation for a resolve to observe a half-built map.
+  function commitVirtualFiles(built: BuiltRoutes) {
+    routes = built;
+    virtualFiles.clear();
+    entryTemplates = new Set();
+    entryTemplateImporters = new Set();
+
+    for (const route of routes.list) {
+      if (route.templateFilePath) {
+        entryTemplates.add(normalizePath(route.templateFilePath));
       }
-      for (const route of Object.values(routes.special) as Route[]) {
-        if (route.templateFilePath) {
-          entryTemplates.add(normalizePath(route.templateFilePath));
-        }
+      for (const middleware of route.middleware) {
+        entryTemplateImporters.add(normalizePath(middleware.filePath));
       }
-
-      if (routes.middleware.length) {
-        virtualFiles.set(path.posix.join(root, MIDDLEWARE_FILENAME), "");
-      }
-      virtualFiles.set(path.posix.join(root, ROUTER_FILENAME), "");
-
-      for (const externalRoute of externalRoutes) {
-        for (const { entryFile } of externalRoute.routes) {
-          if (/\.marko(\?.*)?$/i.test(entryFile)) {
-            entryTemplates.add(normalizePath(entryFile));
-          } else {
-            entryTemplateImporters.add(normalizePath(entryFile));
-          }
-        }
+      if (route.handler) {
+        entryTemplateImporters.add(normalizePath(route.handler.filePath));
       }
 
-      return routes;
-    })().catch((err) => {
-      // Point coding agents at the cheat sheet on route-build errors,
-      // whichever plugin hook triggered the build.
-      throw appendAgentFixGuide(err);
-    }));
+      virtualFiles.set(
+        path.posix.join(root, getRouteVirtualFileName(route)),
+        "",
+      );
+    }
+    for (const route of Object.values(routes.special) as Route[]) {
+      if (route.templateFilePath) {
+        entryTemplates.add(normalizePath(route.templateFilePath));
+      }
+    }
+
+    if (routes.middleware.length) {
+      virtualFiles.set(path.posix.join(root, MIDDLEWARE_FILENAME), "");
+    }
+    virtualFiles.set(path.posix.join(root, ROUTER_FILENAME), "");
+
+    for (const externalRoute of externalRoutes) {
+      for (const { entryFile } of externalRoute.routes) {
+        if (/\.marko(\?.*)?$/i.test(entryFile)) {
+          entryTemplates.add(normalizePath(entryFile));
+        } else {
+          entryTemplateImporters.add(normalizePath(entryFile));
+        }
+      }
+    }
   }
 
   async function writeEntryTemplate(context: PluginContext, route: Route) {

--- a/packages/run/src/vite/plugin.ts
+++ b/packages/run/src/vite/plugin.ts
@@ -246,8 +246,6 @@ export default function markoRun(opts: Options = {}): Plugin[] {
           }
         }
 
-        // From here down is synchronous, so the shared state swaps atomically:
-        // no awaits for a resolve to observe a half-built map.
         routes = built;
         virtualFiles.clear();
         entryTemplates = new Set();

--- a/packages/run/src/vite/plugin.ts
+++ b/packages/run/src/vite/plugin.ts
@@ -208,15 +208,88 @@ export default function markoRun(opts: Options = {}): Plugin[] {
       buildingVirtualFiles = true;
       try {
         let version: number;
-        let built: BuiltRoutes;
+        let built: BuiltRoutes | undefined;
         // The walk has no shared side effects, so a build superseded mid-walk
-        // just walks again; only a current walk commits, exactly once.
+        // just walks again; everything after the loop commits exactly once.
         do {
           version = buildVirtualFilesVersion;
-          built = await walkRoutes();
+          built = fs.existsSync(resolvedRoutesDir)
+            ? await buildRoutes(
+                {
+                  walker: createFSWalker(resolvedRoutesDir),
+                },
+                entryFilesDir,
+              )
+            : undefined;
         } while (version !== buildVirtualFilesVersion);
-        commitVirtualFiles(built);
-        return built;
+
+        if (built) {
+          if (
+            !isBuild &&
+            !built.list.length &&
+            !Object.keys(built.special).length
+          ) {
+            console.warn(`No routes found in ${resolvedRoutesDir}`);
+          }
+        } else {
+          built = {
+            list: [],
+            special: {},
+            middleware: [],
+          };
+
+          if (!isBuild) {
+            console.warn(
+              `Routes directory ${resolvedRoutesDir} does not exist`,
+            );
+          }
+        }
+
+        // From here down is synchronous, so the shared state swaps atomically:
+        // no awaits for a resolve to observe a half-built map.
+        routes = built;
+        virtualFiles.clear();
+        entryTemplates = new Set();
+        entryTemplateImporters = new Set();
+
+        for (const route of routes.list) {
+          if (route.templateFilePath) {
+            entryTemplates.add(normalizePath(route.templateFilePath));
+          }
+          for (const middleware of route.middleware) {
+            entryTemplateImporters.add(normalizePath(middleware.filePath));
+          }
+          if (route.handler) {
+            entryTemplateImporters.add(normalizePath(route.handler.filePath));
+          }
+
+          virtualFiles.set(
+            path.posix.join(root, getRouteVirtualFileName(route)),
+            "",
+          );
+        }
+        for (const route of Object.values(routes.special) as Route[]) {
+          if (route.templateFilePath) {
+            entryTemplates.add(normalizePath(route.templateFilePath));
+          }
+        }
+
+        if (routes.middleware.length) {
+          virtualFiles.set(path.posix.join(root, MIDDLEWARE_FILENAME), "");
+        }
+        virtualFiles.set(path.posix.join(root, ROUTER_FILENAME), "");
+
+        for (const externalRoute of externalRoutes) {
+          for (const { entryFile } of externalRoute.routes) {
+            if (/\.marko(\?.*)?$/i.test(entryFile)) {
+              entryTemplates.add(normalizePath(entryFile));
+            } else {
+              entryTemplateImporters.add(normalizePath(entryFile));
+            }
+          }
+        }
+
+        return routes;
       } finally {
         buildingVirtualFiles = false;
       }
@@ -225,83 +298,6 @@ export default function markoRun(opts: Options = {}): Plugin[] {
       // whichever plugin hook triggered the build.
       throw appendAgentFixGuide(err);
     }));
-  }
-
-  async function walkRoutes(): Promise<BuiltRoutes> {
-    if (fs.existsSync(resolvedRoutesDir)) {
-      const built = await buildRoutes(
-        {
-          walker: createFSWalker(resolvedRoutesDir),
-        },
-        entryFilesDir,
-      );
-
-      if (
-        !isBuild &&
-        !built.list.length &&
-        !Object.keys(built.special).length
-      ) {
-        console.warn(`No routes found in ${resolvedRoutesDir}`);
-      }
-
-      return built;
-    }
-
-    if (!isBuild) {
-      console.warn(`Routes directory ${resolvedRoutesDir} does not exist`);
-    }
-
-    return {
-      list: [],
-      special: {},
-      middleware: [],
-    };
-  }
-
-  // Synchronous, so the shared state swaps atomically: no awaits between the
-  // clear and the repopulation for a resolve to observe a half-built map.
-  function commitVirtualFiles(built: BuiltRoutes) {
-    routes = built;
-    virtualFiles.clear();
-    entryTemplates = new Set();
-    entryTemplateImporters = new Set();
-
-    for (const route of routes.list) {
-      if (route.templateFilePath) {
-        entryTemplates.add(normalizePath(route.templateFilePath));
-      }
-      for (const middleware of route.middleware) {
-        entryTemplateImporters.add(normalizePath(middleware.filePath));
-      }
-      if (route.handler) {
-        entryTemplateImporters.add(normalizePath(route.handler.filePath));
-      }
-
-      virtualFiles.set(
-        path.posix.join(root, getRouteVirtualFileName(route)),
-        "",
-      );
-    }
-    for (const route of Object.values(routes.special) as Route[]) {
-      if (route.templateFilePath) {
-        entryTemplates.add(normalizePath(route.templateFilePath));
-      }
-    }
-
-    if (routes.middleware.length) {
-      virtualFiles.set(path.posix.join(root, MIDDLEWARE_FILENAME), "");
-    }
-    virtualFiles.set(path.posix.join(root, ROUTER_FILENAME), "");
-
-    for (const externalRoute of externalRoutes) {
-      for (const { entryFile } of externalRoute.routes) {
-        if (/\.marko(\?.*)?$/i.test(entryFile)) {
-          entryTemplates.add(normalizePath(entryFile));
-        } else {
-          entryTemplateImporters.add(normalizePath(entryFile));
-        }
-      }
-    }
   }
 
   async function writeEntryTemplate(context: PluginContext, route: Route) {

--- a/packages/run/src/vite/plugin.ts
+++ b/packages/run/src/vite/plugin.ts
@@ -207,21 +207,21 @@ export default function markoRun(opts: Options = {}): Plugin[] {
     return (buildVirtualFilesResult ??= (async () => {
       buildingVirtualFiles = true;
       try {
-        let version: number;
         let built: BuiltRoutes | undefined;
-        // The walk has no shared side effects, so a build superseded mid-walk
-        // just walks again; everything after the loop commits exactly once.
-        do {
-          version = buildVirtualFilesVersion;
-          built = fs.existsSync(resolvedRoutesDir)
-            ? await buildRoutes(
-                {
-                  walker: createFSWalker(resolvedRoutesDir),
-                },
-                entryFilesDir,
-              )
-            : undefined;
-        } while (version !== buildVirtualFilesVersion);
+        if (fs.existsSync(resolvedRoutesDir)) {
+          // The walk has no shared side effects, so a build superseded
+          // mid-walk just walks again; after the loop commits exactly once.
+          let version: number;
+          do {
+            version = buildVirtualFilesVersion;
+            built = await buildRoutes(
+              {
+                walker: createFSWalker(resolvedRoutesDir),
+              },
+              entryFilesDir,
+            );
+          } while (version !== buildVirtualFilesVersion);
+        }
 
         if (built) {
           if (

--- a/packages/run/src/vite/plugin.ts
+++ b/packages/run/src/vite/plugin.ts
@@ -190,17 +190,15 @@ export default function markoRun(opts: Options = {}): Plugin[] {
     }
   }
 
+  // Nonzero while a build is in flight; each invalidation bumps it so the
+  // build's loop re-walks, and every awaiter settles on current routes.
   let buildVirtualFilesVersion = 0;
-  let buildingVirtualFiles = false;
   let buildVirtualFilesResult: Promise<BuiltRoutes> | undefined;
 
-  // Invalidation keeps an in-flight build as the memo: its loop observes the
-  // version bump and re-walks, so every awaiter settles on current routes.
   function invalidateVirtualFiles() {
-    if (buildingVirtualFiles) {
+    if (buildVirtualFilesVersion > 0) {
       buildVirtualFilesVersion++;
     } else {
-      buildVirtualFilesVersion = 0;
       buildVirtualFilesResult = undefined;
     }
     renderVirtualFilesResult = undefined;
@@ -209,7 +207,7 @@ export default function markoRun(opts: Options = {}): Plugin[] {
 
   function buildVirtualFiles() {
     return (buildVirtualFilesResult ??= (async () => {
-      buildingVirtualFiles = true;
+      buildVirtualFilesVersion = 1;
       try {
         let built: BuiltRoutes | undefined;
         if (fs.existsSync(resolvedRoutesDir)) {
@@ -295,7 +293,7 @@ export default function markoRun(opts: Options = {}): Plugin[] {
 
         return routes;
       } finally {
-        buildingVirtualFiles = false;
+        buildVirtualFilesVersion = 0;
       }
     })().catch((err) => {
       // Point coding agents at the cheat sheet on route-build errors,

--- a/packages/run/src/vite/plugin.ts
+++ b/packages/run/src/vite/plugin.ts
@@ -197,8 +197,12 @@ export default function markoRun(opts: Options = {}): Plugin[] {
   // Invalidation keeps an in-flight build as the memo: its loop observes the
   // version bump and re-walks, so every awaiter settles on current routes.
   function invalidateVirtualFiles() {
-    buildVirtualFilesVersion++;
-    if (!buildingVirtualFiles) buildVirtualFilesResult = undefined;
+    if (buildingVirtualFiles) {
+      buildVirtualFilesVersion++;
+    } else {
+      buildVirtualFilesVersion = 0;
+      buildVirtualFilesResult = undefined;
+    }
     renderVirtualFilesResult = undefined;
     routeMarkoApiCache = undefined;
   }

--- a/packages/run/src/vite/plugin.ts
+++ b/packages/run/src/vite/plugin.ts
@@ -662,7 +662,12 @@ export default function markoRun(opts: Options = {}): Plugin[] {
                 } else {
                   // Rebuild before invalidating: a restored route's entry must
                   // be evicted too, and only the fresh map knows its key.
-                  await buildVirtualFiles();
+                  try {
+                    await buildVirtualFiles();
+                  } catch {
+                    // Nothing awaits this listener; the next request's
+                    // renderVirtualFiles surfaces the build error instead.
+                  }
                   for (const file of virtualFiles.keys()) {
                     staleFiles.add(file);
                   }

--- a/packages/run/src/vite/plugin.ts
+++ b/packages/run/src/vite/plugin.ts
@@ -190,26 +190,41 @@ export default function markoRun(opts: Options = {}): Plugin[] {
     }
   }
 
+  let buildVirtualFilesVersion = 0;
+  let buildingVirtualFiles = false;
   let buildVirtualFilesResult: Promise<BuiltRoutes> | undefined;
-  let buildVirtualFilesQueue: Promise<unknown> = Promise.resolve();
+
+  // Invalidation keeps an in-flight build as the memo: its loop observes the
+  // version bump and re-walks, so every awaiter settles on current routes.
+  function invalidateVirtualFiles() {
+    buildVirtualFilesVersion++;
+    if (!buildingVirtualFiles) buildVirtualFilesResult = undefined;
+    renderVirtualFilesResult = undefined;
+    routeMarkoApiCache = undefined;
+  }
+
   function buildVirtualFiles() {
-    if (!buildVirtualFilesResult) {
-      // Serialized: a rebuild requested while one is in flight waits for it,
-      // so two walks never interleave their commits into the shared state.
-      const build = buildVirtualFilesQueue
-        .then(walkRoutes, walkRoutes)
-        .then((built) => {
-          commitVirtualFiles(built);
-          return built;
-        });
-      buildVirtualFilesQueue = build;
-      buildVirtualFilesResult = build.catch((err) => {
-        // Point coding agents at the cheat sheet on route-build errors,
-        // whichever plugin hook triggered the build.
-        throw appendAgentFixGuide(err);
-      });
-    }
-    return buildVirtualFilesResult;
+    return (buildVirtualFilesResult ??= (async () => {
+      buildingVirtualFiles = true;
+      try {
+        let version: number;
+        let built: BuiltRoutes;
+        // The walk has no shared side effects, so a build superseded mid-walk
+        // just walks again; only a current walk commits, exactly once.
+        do {
+          version = buildVirtualFilesVersion;
+          built = await walkRoutes();
+        } while (version !== buildVirtualFilesVersion);
+        commitVirtualFiles(built);
+        return built;
+      } finally {
+        buildingVirtualFiles = false;
+      }
+    })().catch((err) => {
+      // Point coding agents at the cheat sheet on route-build errors,
+      // whichever plugin hook triggered the build.
+      throw appendAgentFixGuide(err);
+    }));
   }
 
   async function walkRoutes(): Promise<BuiltRoutes> {
@@ -664,9 +679,7 @@ export default function markoRun(opts: Options = {}): Plugin[] {
                     filename === runtimeInclude))
               ) {
                 const staleFiles = new Set(virtualFiles.keys());
-                buildVirtualFilesResult = undefined;
-                renderVirtualFilesResult = undefined;
-                routeMarkoApiCache = undefined;
+                invalidateVirtualFiles();
 
                 // Only a change leaves a live module chain to poke. A delete
                 // takes its chain, and an add can leave a stale one behind.

--- a/packages/run/src/vite/utils/agent-fix-guide.ts
+++ b/packages/run/src/vite/utils/agent-fix-guide.ts
@@ -49,18 +49,20 @@ export function agentRouteFixGuide(): string {
 }
 
 // Env markers terminal coding agents set.
+export const AGENT_ENV_VARS = [
+  "CLAUDECODE",
+  "CLAUDE_CODE",
+  "CURSOR_AGENT",
+  "GEMINI_CLI",
+  "CODEX_SANDBOX",
+  "CODEX_THREAD_ID",
+  "AI_AGENT",
+];
+
 function isCodingAgent() {
   return (
     typeof process === "object" &&
-    !!(
-      process.env.CLAUDECODE ||
-      process.env.CLAUDE_CODE ||
-      process.env.CURSOR_AGENT ||
-      process.env.GEMINI_CLI ||
-      process.env.CODEX_SANDBOX ||
-      process.env.CODEX_THREAD_ID ||
-      process.env.AI_AGENT
-    )
+    AGENT_ENV_VARS.some((key) => process.env[key])
   );
 }
 


### PR DESCRIPTION
Deleting a route file and restoring it in dev left every request to that route 500ing with `route.handler is not a function` until the server restarted: the watcher handler emitted module invalidations from the stale pre-rebuild `virtualFiles` map, which no longer contained the restored route's entry key, so a cached-empty entry module was never evicted. The handler now rebuilds the map first and invalidates the union of old and new keys. This also fixes the flaky `dev-delete-route` test (10/10 with a cleared Vite cache, from ~60%).

Also makes fixture snapshots terminal-independent by stripping the agent env markers in the test bootstrap — the `error-invalid-routes` snapshot mismatch on `main` was the agent-gated fix guide leaking into rendered-error output.