### PR TITLE
fix: tolerate nullish options in the client-build href helpers

### DIFF
--- a/.changeset/href-nullish-options.md
+++ b/.changeset/href-nullish-options.md
@@ -1,0 +1,5 @@
+---
+"@marko/run": patch
+---
+
+`Run.href(path, options)` with a nullish options value no longer throws in production client builds.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -2,12 +2,6 @@
 
 Out-of-scope defects noticed while working on something else. Format and rules: [README.md](README.md).
 
-## Guard the client-build `href` helpers against nullish options so `Run.href(path, maybeOptions)` doesn't throw in production
-
-`packages/run/src/runtime/url-builder.ts` › `href_values` | 2026-08-03 | impact:med | effort:low
-
-`href` deliberately tolerates a nullish options argument (`return options ? … : path`), but the client-build rewrite in `packages/run/src/vite/utils/href-replace.ts` drops that guard: `Run.href("/about", opts)` becomes ``href_keys`${opts}/about` `` and `Run.href("/users/$id", { ...defaults, params: { id } })` becomes ``href_values`${defaults}/users/${id}` ``, both handing the value straight to the module-private `joinHref`, which reads `options.search` unconditionally. Both call shapes type-check under `strict` — `Href` in `packages/run/src/runtime/types.ts` declares `[options?: HrefOptions<Path>]` for param-less paths, and spreading a possibly-undefined object into an object literal is legal — so `href("/about", undefined)` returns `"/about"` while the rewritten form throws `TypeError: Cannot read properties of undefined (reading 'search')`, and `{ ...undefined, params: { id } }` yields `/users/1` before the rewrite and a throw after it. Since `packages/run/src/vite/plugin.ts` gates the transform on `!isBuild || isSSRBuild`, dev and SSR keep the guarded `href` and only the production client bundle throws, killing that component's hydration with no earlier signal. Make `joinHref` nullish-tolerant (`options?.search`, `options?.hash`) so the rewritten helpers match `href`, and add nullish-options cases to `packages/run/src/__tests__/url-builder.test.ts`, which only ever passes defined objects — `packages/run/src/vite/__tests__/href-replace.test.ts` already pins the rewrites that drop the guard.
-
 ## Skip nullish `search` values in `joinHref` instead of serializing them as `"undefined"`/`"null"`
 
 `packages/run/src/runtime/url-builder.ts` › `joinHref` | 2026-08-03 | impact:med | effort:low

--- a/packages/run/src/__tests__/url-builder.test.ts
+++ b/packages/run/src/__tests__/url-builder.test.ts
@@ -276,3 +276,21 @@ describe("url-builder", () => {
     });
   });
 });
+
+// The client-build rewrite hands `Run.href(path, opts)` to these helpers
+// without `href`'s own nullish guard, so they must tolerate it themselves.
+describe("nullish options", () => {
+  it("href returns the path for a nullish options argument", () => {
+    assert.equal(href("/about", undefined as any), "/about");
+  });
+
+  it("href_keys tolerates nullish options for a param-less path", () => {
+    const opts = undefined as any;
+    assert.equal(href_keys`${opts}/about`, "/about");
+  });
+
+  it("href_values tolerates nullish spread options", () => {
+    const defaults = undefined as any;
+    assert.equal(href_values`${defaults}/users/${1}`, "/users/1");
+  });
+});

--- a/packages/run/src/runtime/url-builder.ts
+++ b/packages/run/src/runtime/url-builder.ts
@@ -80,12 +80,16 @@ export function href_keys(
   return href_values(strings, options, ...keys.map((k) => options.params[k]));
 }
 
-function joinHref(path: string, options: HrefOptions<any>) {
+// Nullish-tolerant: the client-build rewrite routes `Run.href(path, opts)`
+// here without `href`'s own `options` guard, and `opts` may be undefined.
+function joinHref(path: string, options?: HrefOptions<any>) {
   let result = path;
-  if (options.search) {
+  if (options?.search) {
     const query = "" + new URLSearchParams(options.search);
     if (query) result += "?" + query;
   }
-  if (options.hash || options.hash === 0) result += "#" + encode(options.hash);
+  if (options?.hash || options?.hash === 0) {
+    result += "#" + encode(options.hash);
+  }
   return result;
 }

--- a/packages/run/src/runtime/url-builder.ts
+++ b/packages/run/src/runtime/url-builder.ts
@@ -82,12 +82,14 @@ export function href_keys(
 
 function joinHref(path: string, options?: HrefOptions<any>) {
   let result = path;
-  if (options?.search) {
-    const query = "" + new URLSearchParams(options.search);
-    if (query) result += "?" + query;
-  }
-  if (options?.hash || options?.hash === 0) {
-    result += "#" + encode(options.hash);
+  if (options) {
+    if (options.search) {
+      const query = "" + new URLSearchParams(options.search);
+      if (query) result += "?" + query;
+    }
+    if (options.hash || options.hash === 0) {
+      result += "#" + encode(options.hash);
+    }
   }
   return result;
 }

--- a/packages/run/src/runtime/url-builder.ts
+++ b/packages/run/src/runtime/url-builder.ts
@@ -66,30 +66,26 @@ export function href_path(
 
 export function href_values(
   strings: TemplateStringsArray,
-  options: HrefOptions<any>,
+  options: HrefOptions<any> | null | undefined,
   ...params: (string | number | (string | number)[])[]
 ) {
-  return joinHref(href_path(strings, ...params), options);
+  return joinHref(href_path(strings, ...params), options || {});
 }
 
 export function href_keys(
   strings: TemplateStringsArray,
-  options: HrefOptions,
+  options: HrefOptions | null | undefined,
   ...keys: string[]
 ) {
-  return href_values(strings, options, ...keys.map((k) => options.params[k]));
+  return href_values(strings, options, ...keys.map((k) => options!.params[k]));
 }
 
-function joinHref(path: string, options?: HrefOptions<any>) {
+function joinHref(path: string, options: HrefOptions<any>) {
   let result = path;
-  if (options) {
-    if (options.search) {
-      const query = "" + new URLSearchParams(options.search);
-      if (query) result += "?" + query;
-    }
-    if (options.hash || options.hash === 0) {
-      result += "#" + encode(options.hash);
-    }
+  if (options.search) {
+    const query = "" + new URLSearchParams(options.search);
+    if (query) result += "?" + query;
   }
+  if (options.hash || options.hash === 0) result += "#" + encode(options.hash);
   return result;
 }

--- a/packages/run/src/runtime/url-builder.ts
+++ b/packages/run/src/runtime/url-builder.ts
@@ -80,8 +80,6 @@ export function href_keys(
   return href_values(strings, options, ...keys.map((k) => options.params[k]));
 }
 
-// Nullish-tolerant: the client-build rewrite routes `Run.href(path, opts)`
-// here without `href`'s own `options` guard, and `opts` may be undefined.
 function joinHref(path: string, options?: HrefOptions<any>) {
   let result = path;
   if (options?.search) {


### PR DESCRIPTION
`href` guards a nullish options argument, but the production client-build rewrite bypassed it: `Run.href(path, opts)` compiled to `href_keys`/`href_values` calls that read `options.search` unconditionally, so an undefined options value type-checked, worked in dev and SSR, and threw `Cannot read properties of undefined (reading 'search')` only in the shipped bundle. The helpers now accept nullish options and normalize once (`options || {}`) before joining.