### PR TITLE
fix: omit undefined search values from Run.href output

### DIFF
--- a/.changeset/href-nullish-search.md
+++ b/.changeset/href-nullish-search.md
@@ -2,4 +2,4 @@
 "@marko/run": patch
 ---
 
-`Run.href` now omits nullish `search` values instead of serializing them as `?key=undefined`/`?key=null`.
+`Run.href` now omits undefined `search` values instead of serializing them as `?key=undefined`.

--- a/.changeset/href-nullish-search.md
+++ b/.changeset/href-nullish-search.md
@@ -2,4 +2,4 @@
 "@marko/run": patch
 ---
 
-`Run.href` now omits undefined `search` values instead of serializing them as `?key=undefined`.
+`Run.href` now omits undefined `search` values instead of serializing them as `?key=undefined`. Nested `Run.href` calls no longer corrupt the build-time rewrite.

--- a/.changeset/href-nullish-search.md
+++ b/.changeset/href-nullish-search.md
@@ -1,0 +1,5 @@
+---
+"@marko/run": patch
+---
+
+`Run.href` now omits nullish `search` values instead of serializing them as `?key=undefined`/`?key=null`.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -2,12 +2,6 @@
 
 Out-of-scope defects noticed while working on something else. Format and rules: [README.md](README.md).
 
-## Skip nullish `search` values in `joinHref` instead of serializing them as `"undefined"`/`"null"`
-
-`packages/run/src/runtime/url-builder.ts` › `joinHref` | 2026-08-03 | impact:med | effort:low
-
-`joinHref` builds the query with `"" + new URLSearchParams(options.search)`, and `URLSearchParams` stringifies nullish values, so `Run.href("/search", { search: { q, page } })` with `page === undefined` yields `/search?q=hi&page=undefined`, and a `null` yields `?tag=null`. This is type-legal rather than user error: `HrefOptions`' `search` (`packages/run/src/runtime/types.ts`) maps over the validator's input type and preserves optional modifiers, so a Standard Schema declaring `page?: string` types as `{ q: string | number; page?: string | number | undefined }` and accepts an explicit `undefined`; a route with no generated types widens `search` to `{}` and accepts anything. Every href tier funnels here — `href`, `href_values` and `href_keys` all call `joinHref` — and the fully-static tier in `packages/run/src/vite/utils/href-replace.ts` bakes `Run.href("/users", { search: { tag: null } })` into the literal `"/users?tag=null"` at build time. The receiving route then sees the literal string, because `createContext`'s `get search()` derives the record from `url.searchParams` before handing it to the `search` validator, so a filter silently matches `"undefined"` or validation fails on a key the caller meant to omit. Skip `undefined`/`null` entries before appending — mirroring the adjacent `hash` guard (`options.hash || options.hash === 0`) — and add coverage to `packages/run/src/__tests__/url-builder.test.ts`, which currently only exercises defined search values.
-
 ## Skip `Run.href` calls nested inside an already-replaced range — today they emit invalid JS and fail the client build
 
 `packages/run/src/vite/utils/href-replace.ts` › `findHrefReplacements` | 2026-08-03 | impact:med | effort:low

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -2,12 +2,6 @@
 
 Out-of-scope defects noticed while working on something else. Format and rules: [README.md](README.md).
 
-## Skip `Run.href` calls nested inside an already-replaced range — today they emit invalid JS and fail the client build
-
-`packages/run/src/vite/utils/href-replace.ts` › `findHrefReplacements` | 2026-08-03 | impact:med | effort:low
-
-`findHrefReplacements` walks the whole AST without pruning, so a `Run.href` call nested inside another call's `params` value records its own edit inside a range the outer call already replaced, and the post-transform in `packages/run/src/vite/plugin.ts` applies every edit to one `RolldownMagicString` with no overlap check. In the tier-1b shape the inner overwrite lands inside the removed `params` property and re-inserts text: `Run.href("/thing/$id", { params: { id: Run.href("/thing/$id", { params: { id: 9 } }) }, search: { q } })` emits ``href_values`${{ "/thing/9"search: { q } }}...` `` and the client build dies with a rolldown `PARSE_ERROR` ("Expected `:` but found `Identifier`") pointed at the author's valid `.marko` file. In the tier-1a shape (params only) the inner overwrite instead throws `Cannot split a chunk that has already been edited`, and the bare `catch {}` in plugin.ts swallows it, so the entire module silently loses the optimization and ships raw `Run.href` calls plus `import "virtual:marko-run/runtime/client"`. Prune the walk below any node whose full range was replaced (or drop replacements overlapping an already-recorded range), and narrow the `catch` in plugin.ts so a genuine regression in this pass is not invisible. `packages/run/src/vite/__tests__/href-replace.test.ts` and the `packages/run/src/__tests__/fixtures/href-replacement` fixture only exercise flat calls; nesting under `search` alone is unaffected because that tier leaves the options range intact.
-
 ## Escape emitted string literals in the generated router instead of raw-interpolating segment and param names
 
 `packages/run/src/vite/codegen/index.ts` › `renderRouter` | 2026-08-03 | impact:med | effort:low

--- a/packages/run/src/__tests__/url-builder.test.ts
+++ b/packages/run/src/__tests__/url-builder.test.ts
@@ -294,3 +294,37 @@ describe("nullish options", () => {
     assert.equal(href_values`${defaults}/users/${1}`, "/users/1");
   });
 });
+
+describe("nullish search values", () => {
+  it("omits undefined and null search entries", () => {
+    assert.equal(
+      href("/about", {
+        search: { q: "hi", page: undefined, tag: null },
+      } as any),
+      "/about?q=hi",
+    );
+  });
+
+  it("drops the query entirely when every entry is nullish", () => {
+    assert.equal(
+      href("/about", { search: { page: undefined } } as any),
+      "/about",
+    );
+  });
+
+  it("keeps falsy but defined values", () => {
+    assert.equal(
+      href("/about", { search: { q: "", n: 0 } } as any),
+      "/about?q=&n=0",
+    );
+  });
+
+  it("applies through the rewritten helper tiers", () => {
+    const opts = { params: { id: 1 }, search: { q: "x", page: undefined } };
+    assert.equal(href_keys`${opts}/users/${"id"}`, "/users/1?q=x");
+    assert.equal(
+      href_values`${{ search: { tag: null } }}/users/${2}`,
+      "/users/2",
+    );
+  });
+});

--- a/packages/run/src/__tests__/url-builder.test.ts
+++ b/packages/run/src/__tests__/url-builder.test.ts
@@ -300,16 +300,13 @@ describe("nullish search values", () => {
     assert.equal(
       href("/about", {
         search: { q: "hi", page: undefined, tag: null },
-      } as any),
+      }),
       "/about?q=hi&tag=null",
     );
   });
 
   it("drops the query entirely when every entry is undefined", () => {
-    assert.equal(
-      href("/about", { search: { page: undefined } } as any),
-      "/about",
-    );
+    assert.equal(href("/about", { search: { page: undefined } }), "/about");
   });
 
   it("keeps falsy but defined values", () => {

--- a/packages/run/src/__tests__/url-builder.test.ts
+++ b/packages/run/src/__tests__/url-builder.test.ts
@@ -328,3 +328,12 @@ describe("nullish search values", () => {
     );
   });
 });
+
+describe("search value encoding", () => {
+  it("percent-encodes keys and values", () => {
+    assert.equal(
+      href("/about", { search: { "a b": "x&y=z#w" } } as any),
+      "/about?a%20b=x%26y%3Dz%23w",
+    );
+  });
+});

--- a/packages/run/src/__tests__/url-builder.test.ts
+++ b/packages/run/src/__tests__/url-builder.test.ts
@@ -296,16 +296,16 @@ describe("nullish options", () => {
 });
 
 describe("nullish search values", () => {
-  it("omits undefined and null search entries", () => {
+  it("omits undefined search entries and keeps null as a value", () => {
     assert.equal(
       href("/about", {
         search: { q: "hi", page: undefined, tag: null },
       } as any),
-      "/about?q=hi",
+      "/about?q=hi&tag=null",
     );
   });
 
-  it("drops the query entirely when every entry is nullish", () => {
+  it("drops the query entirely when every entry is undefined", () => {
     assert.equal(
       href("/about", { search: { page: undefined } } as any),
       "/about",
@@ -324,7 +324,7 @@ describe("nullish search values", () => {
     assert.equal(href_keys`${opts}/users/${"id"}`, "/users/1?q=x");
     assert.equal(
       href_values`${{ search: { tag: null } }}/users/${2}`,
-      "/users/2",
+      "/users/2?tag=null",
     );
   });
 });

--- a/packages/run/src/runtime/types.ts
+++ b/packages/run/src/runtime/types.ts
@@ -1106,7 +1106,12 @@ export type HrefOptions<
   : HrefBaseOptions<Path>;
 interface HrefBaseOptions<Path extends string> {
   search?: {
-    [K in keyof Valid<GetRawSearchValidator<Path>>]: string | number;
+    // `undefined` omits the entry; `null` serializes as a value.
+    [K in keyof Valid<GetRawSearchValidator<Path>>]:
+      | string
+      | number
+      | null
+      | undefined;
   };
   hash?: string | number;
 }

--- a/packages/run/src/runtime/url-builder.ts
+++ b/packages/run/src/runtime/url-builder.ts
@@ -83,7 +83,14 @@ export function href_keys(
 function joinHref(path: string, options: HrefOptions<any>) {
   let result = path;
   if (options.search) {
-    const query = "" + new URLSearchParams(options.search);
+    // Built entry by entry: URLSearchParams would serialize a nullish value
+    // as "undefined"/"null", and a caller's optional key means "omit".
+    const searchParams = new URLSearchParams();
+    for (const key in options.search) {
+      const value = (options.search as Record<string, unknown>)[key];
+      if (value != null) searchParams.append(key, value as string);
+    }
+    const query = "" + searchParams;
     if (query) result += "?" + query;
   }
   if (options.hash || options.hash === 0) result += "#" + encode(options.hash);

--- a/packages/run/src/runtime/url-builder.ts
+++ b/packages/run/src/runtime/url-builder.ts
@@ -85,7 +85,7 @@ function joinHref(path: string, options: HrefOptions<any>) {
   let sep = "?";
   for (const key in options.search) {
     const value = options.search[key as keyof typeof options.search];
-    if (value != null) {
+    if (value !== void 0) {
       result += `${sep}${encode(key)}=${encode(value)}`;
       sep = "&";
     }

--- a/packages/run/src/runtime/url-builder.ts
+++ b/packages/run/src/runtime/url-builder.ts
@@ -82,16 +82,13 @@ export function href_keys(
 
 function joinHref(path: string, options: HrefOptions<any>) {
   let result = path;
-  if (options.search) {
-    // Built entry by entry: URLSearchParams would serialize a nullish value
-    // as "undefined"/"null", and a caller's optional key means "omit".
-    const searchParams = new URLSearchParams();
-    for (const key in options.search) {
-      const value = (options.search as Record<string, unknown>)[key];
-      if (value != null) searchParams.append(key, value as string);
+  let sep = "?";
+  for (const key in options.search) {
+    const value = options.search[key as keyof typeof options.search];
+    if (value != null) {
+      result += `${sep}${encode(key)}=${encode(value)}`;
+      sep = "&";
     }
-    const query = "" + searchParams;
-    if (query) result += "?" + query;
   }
   if (options.hash || options.hash === 0) result += "#" + encode(options.hash);
   return result;

--- a/packages/run/src/runtime/url-builder.ts
+++ b/packages/run/src/runtime/url-builder.ts
@@ -82,8 +82,8 @@ export function href_keys(
 
 function joinHref(path: string, { search, hash }: HrefOptions<any>) {
   let sep = "?";
-  for (const key in search) {
-    const value = search[key as keyof typeof search];
+  for (const key of search ? Object.keys(search) : []) {
+    const value = search![key as keyof typeof search];
     if (value !== void 0) {
       path += `${sep}${encode(key)}=${encode(value)}`;
       sep = "&";

--- a/packages/run/src/runtime/url-builder.ts
+++ b/packages/run/src/runtime/url-builder.ts
@@ -82,8 +82,8 @@ export function href_keys(
 
 function joinHref(path: string, { search, hash }: HrefOptions<any>) {
   let sep = "?";
-  for (const key of search ? Object.keys(search) : []) {
-    const value = search![key as keyof typeof search];
+  for (const key in search) {
+    const value = search[key as keyof typeof search];
     if (value !== void 0) {
       path += `${sep}${encode(key)}=${encode(value)}`;
       sep = "&";

--- a/packages/run/src/runtime/url-builder.ts
+++ b/packages/run/src/runtime/url-builder.ts
@@ -80,16 +80,14 @@ export function href_keys(
   return href_values(strings, options, ...keys.map((k) => options!.params[k]));
 }
 
-function joinHref(path: string, options: HrefOptions<any>) {
-  let result = path;
+function joinHref(path: string, { search, hash }: HrefOptions<any>) {
   let sep = "?";
-  for (const key in options.search) {
-    const value = options.search[key as keyof typeof options.search];
+  for (const key in search) {
+    const value = search[key as keyof typeof search];
     if (value !== void 0) {
-      result += `${sep}${encode(key)}=${encode(value)}`;
+      path += `${sep}${encode(key)}=${encode(value)}`;
       sep = "&";
     }
   }
-  if (options.hash || options.hash === 0) result += "#" + encode(options.hash);
-  return result;
+  return hash || hash === 0 ? `${path}#${encode(hash)}` : path;
 }

--- a/packages/run/src/runtime/url-builder.ts
+++ b/packages/run/src/runtime/url-builder.ts
@@ -82,6 +82,7 @@ export function href_keys(
 
 function joinHref(path: string, { search, hash }: HrefOptions<any>) {
   let sep = "?";
+  // `for...in` is intentional: including enumerable inherited keys is fine.
   for (const key in search) {
     const value = search[key as keyof typeof search];
     if (value !== void 0) {

--- a/packages/run/src/vite/__tests__/href-replace.test.ts
+++ b/packages/run/src/vite/__tests__/href-replace.test.ts
@@ -302,3 +302,30 @@ describe("href-replace", () => {
     });
   });
 });
+
+describe("nested Run.href calls", () => {
+  it("falls back on the outer call and optimizes the inner one (params only)", () => {
+    assert.equal(
+      apply(
+        `Run.href("/thing/$id", { params: { id: Run.href("/thing/$id", { params: { id: 9 } }) } })`,
+      ),
+      `href("/thing/$id", { params: { id: "/thing/9" } })`,
+    );
+  });
+
+  it("falls back on the outer call when other options are present", () => {
+    assert.equal(
+      apply(
+        `Run.href("/thing/$id", { params: { id: Run.href("/a") }, search: { q } })`,
+      ),
+      `href("/thing/$id", { params: { id: "/a" }, search: { q } })`,
+    );
+  });
+
+  it("still optimizes a nested call inside search", () => {
+    assert.equal(
+      apply(`Run.href("/a", { search: { to: Run.href("/b") } })`),
+      `href("/a", { search: { to: "/b" } })`,
+    );
+  });
+});

--- a/packages/run/src/vite/plugin.ts
+++ b/packages/run/src/vite/plugin.ts
@@ -857,7 +857,10 @@ export default function markoRun(opts: Options = {}): Plugin[] {
           }
 
           return null;
-        } catch {
+        } catch (error) {
+          // The module ships unoptimized with the client runtime for `Run`,
+          // but a regression in this pass must not be invisible.
+          this.warn(`Run.href optimization failed: ${error}`);
           return {
             code: new RolldownMagicString(code).prepend(
               'import "virtual:marko-run/runtime/client";',

--- a/packages/run/src/vite/utils/href-replace.ts
+++ b/packages/run/src/vite/utils/href-replace.ts
@@ -63,6 +63,11 @@ export function findHrefReplacements(
   ast: Program,
 ): HrefReplacement[] {
   const replacements: HrefReplacement[] = [];
+  const consumed: HrefEdit[] = [];
+  const add = (replacement: HrefReplacement) => {
+    replacements.push(replacement);
+    consumed.push(...replacement.edits);
+  };
 
   if (hasRunBinding(ast)) {
     return replacements;
@@ -70,6 +75,14 @@ export function findHrefReplacements(
 
   walk(ast, (node: Node) => {
     if (node.type !== "CallExpression") return;
+
+    // A call inside a range an outer call already rewrote is dead source;
+    // recording its edits would corrupt the outer replacement.
+    if (
+      consumed.some((edit) => node.start < edit.end && node.end > edit.start)
+    ) {
+      return;
+    }
 
     const callee = node.callee;
     if (
@@ -96,7 +109,7 @@ export function findHrefReplacements(
 
     if (typeof pathString !== "string") {
       // Dynamic path — just replace callee with runtime href
-      replacements.push({
+      add({
         helper: "href",
         edits: [{ start: callee.start, end: callee.end, code: "href" }],
       });
@@ -105,7 +118,7 @@ export function findHrefReplacements(
 
     // No options — tier 0 (just the path string)
     if (args.length === 1) {
-      replacements.push({
+      add({
         helper: false,
         edits: [
           {
@@ -119,6 +132,17 @@ export function findHrefReplacements(
     }
 
     const optionsNode = args[1];
+
+    // A nested call would be copied into (or erased by) the outer rewrite;
+    // replacing only the callee keeps it live for its own optimization pass.
+    if (code.slice(optionsNode.start, optionsNode.end).includes("Run.href")) {
+      add({
+        helper: "href",
+        edits: [{ start: callee.start, end: callee.end, code: "href" }],
+      });
+      return;
+    }
+
     const optionsObject = tryStaticEval(optionsNode)?.value;
 
     if (
@@ -126,7 +150,7 @@ export function findHrefReplacements(
       typeof optionsObject === "object" &&
       !Array.isArray(optionsObject)
     ) {
-      replacements.push({
+      add({
         helper: false,
         edits: [
           {
@@ -149,7 +173,7 @@ export function findHrefReplacements(
 
         if (params.only) {
           // Tier 1a: href_path — replace entire call
-          replacements.push({
+          add({
             helper: "href_path",
             edits: [
               {
@@ -166,7 +190,7 @@ export function findHrefReplacements(
 
           // `{ ...x }` with params gone is just `x`.
           if (remaining.length === 1 && remaining[0].type === "SpreadElement") {
-            replacements.push({
+            add({
               helper: "href_values",
               edits: [
                 {
@@ -182,7 +206,7 @@ export function findHrefReplacements(
               ],
             });
           } else {
-            replacements.push({
+            add({
               helper: "href_values",
               edits: [
                 {
@@ -215,7 +239,7 @@ export function findHrefReplacements(
     }
 
     // Tier 2: static path, opaque options — wrap options in tagged template
-    replacements.push({
+    add({
       helper: "href_keys",
       edits: [
         { start: node.start, end: optionsNode.start, code: "href_keys`${" },

--- a/packages/run/src/vite/utils/href-replace.ts
+++ b/packages/run/src/vite/utils/href-replace.ts
@@ -85,14 +85,7 @@ export function findHrefReplacements(
     }
 
     const callee = node.callee;
-    if (
-      callee.type !== "MemberExpression" ||
-      callee.computed ||
-      callee.object.type !== "Identifier" ||
-      callee.object.name !== "Run" ||
-      callee.property.type !== "Identifier" ||
-      callee.property.name !== "href"
-    ) {
+    if (!isRunHrefCallee(callee)) {
       return;
     }
 
@@ -135,7 +128,7 @@ export function findHrefReplacements(
 
     // A nested call would be copied into (or erased by) the outer rewrite;
     // replacing only the callee keeps it live for its own optimization pass.
-    if (code.slice(optionsNode.start, optionsNode.end).includes("Run.href")) {
+    if (containsRunHrefCall(optionsNode)) {
       add({
         helper: "href",
         edits: [{ start: callee.start, end: callee.end, code: "href" }],
@@ -253,6 +246,27 @@ export function findHrefReplacements(
   });
 
   return replacements;
+}
+
+function isRunHrefCallee(callee: Node): boolean {
+  return (
+    callee.type === "MemberExpression" &&
+    !callee.computed &&
+    callee.object.type === "Identifier" &&
+    callee.object.name === "Run" &&
+    callee.property.type === "Identifier" &&
+    callee.property.name === "href"
+  );
+}
+
+function containsRunHrefCall(node: Node): boolean {
+  let found = false;
+  walk(node, (n: Node) => {
+    if (!found && n.type === "CallExpression" && isRunHrefCallee(n.callee)) {
+      found = true;
+    }
+  });
+  return found;
 }
 
 /**


### PR DESCRIPTION
`joinHref` serialized search entries through `URLSearchParams`, which stringifies missing values — `Run.href("/search", { search: { q, page } })` with `page === undefined` produced `?q=hi&page=undefined`, and the receiving route saw the literal string. The query is now built directly: `undefined` entries are omitted (an optional key means "absent"), `null` still serializes as a value, and keys and values are percent-encoded.