### PR TITLE
fix: don't warn about marko's colocated companion files

### DIFF
--- a/.changeset/routable-lookalike-marko-companions.md
+++ b/.changeset/routable-lookalike-marko-companions.md
@@ -1,0 +1,5 @@
+---
+"@marko/run": patch
+---
+
+Stop warning that Marko's colocated companion files, such as `+page.style.css`, are not routable.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -139,3 +139,9 @@ Dev runs Vite in middleware mode behind marko-run's own listener (`devServer.mid
 `packages/explorer/src/routes/+page.marko` › route table `col-entry` | 2026-08-14 | impact:low | effort:low
 
 The entry cell prints "Handler" whenever `route.handler` exists, without checking that the handler actually exports the row's verb. A route with a page plus a POST-only handler renders its GET (and now QUERY) rows as "Handler → Page", but those requests go straight to the page render — the handler never runs. Gate the "Handler" label on `route.handler.verbs.includes(verb)` (treating the no-verb/"all" row as handler-backed) so the per-verb entry matches what the generated router does.
+
+## Any middle segment makes a file a route, so `+handler.test.ts` registers as a second handler
+
+`packages/run/src/vite/routes/builder.ts` › `RoutableFileRegex` | 2026-08-14 | impact:med | effort:low
+
+`nonMarkoFiles` (and `markoFiles`) allow an arbitrary middle segment — `(+middleware|+handler|+meta)\.(?:.*\.)?(.+)` — and nothing ever reads that group (`matchRoutableFile` and `onFile` only use the type and the trailing extension). A colocated `+handler.test.ts` next to `+handler.ts` therefore builds a second `RoutableFile` of type `handler` for the same directory, and `VDir.addFile` takes both. The same holds for `+page.test.marko`. Either drop the optional middle segment, or ignore known test/spec segments there. Re-verify: add `+handler.test.ts` beside `+handler.ts` in a route directory and inspect `buildRoutes` output.

--- a/packages/run/src/vite/__tests__/lookalike-warnings.test.ts
+++ b/packages/run/src/vite/__tests__/lookalike-warnings.test.ts
@@ -54,6 +54,19 @@ describe("non-routable lookalike warnings", () => {
     assert.deepEqual(warnings, []);
   });
 
+  it("does not flag files marko colocates with a template", async () => {
+    const warnings = await collectWarnings(`
+      +page.marko
+      +page.style.css
+      +page.marko.d.ts
+      +layout.marko
+      +layout.style.less
+      +layout.component.ts
+      +404.component-browser.js
+    `);
+    assert.deepEqual(warnings, []);
+  });
+
   it("does not flag valid routes", async () => {
     const warnings = await collectWarnings(`
       +page.marko

--- a/packages/run/src/vite/__tests__/lookalike-warnings.test.ts
+++ b/packages/run/src/vite/__tests__/lookalike-warnings.test.ts
@@ -63,6 +63,8 @@ describe("non-routable lookalike warnings", () => {
       +layout.style.less
       +layout.component.ts
       +404.component-browser.js
+      account+page.marko
+      account+page.style.css
     `);
     assert.deepEqual(warnings, []);
   });

--- a/packages/run/src/vite/routes/builder.ts
+++ b/packages/run/src/vite/routes/builder.ts
@@ -276,7 +276,7 @@ const bracketFlagReg = /\[[^\]]*\]/g;
 // Marko pulls colocated companions in through their template, so
 // `+page.style.css` beside `+page.marko` is expected rather than a broken route.
 const markoCompanionReg = new RegExp(
-  `^[+](?:${markoFileTypes})\\.(?:style|component|component-browser|marko\\.d)\\.[^.]+$`,
+  `[+](?:${markoFileTypes})\\.(?:style|component|component-browser|marko\\.d)\\.[^.]+$`,
   "i",
 );
 

--- a/packages/run/src/vite/routes/builder.ts
+++ b/packages/run/src/vite/routes/builder.ts
@@ -13,7 +13,8 @@ import { parseFlatRoute } from "./parse";
 import VDir from "./vdir";
 import type { Walker, WalkOptions } from "./walk";
 
-const markoFiles = `(${RoutableFileTypes.Layout}|${RoutableFileTypes.Page}|${RoutableFileTypes.NotFound}|${RoutableFileTypes.Error})\\.(?:.*\\.)?(marko)`;
+const markoFileTypes = `${RoutableFileTypes.Layout}|${RoutableFileTypes.Page}|${RoutableFileTypes.NotFound}|${RoutableFileTypes.Error}`;
+const markoFiles = `(${markoFileTypes})\\.(?:.*\\.)?(marko)`;
 const nonMarkoFiles = `(${RoutableFileTypes.Middleware}|${RoutableFileTypes.Handler}|${RoutableFileTypes.Meta})\\.(?:.*\\.)?(.+)`;
 const RoutableFileRegex = new RegExp(
   `[+](?:${markoFiles}|${nonMarkoFiles})$`,
@@ -272,6 +273,13 @@ function replaceInvalidFilenameChars(str: string) {
 // too; stripped before classifying so `[` and `+` never read as route syntax.
 const bracketFlagReg = /\[[^\]]*\]/g;
 
+// Marko pulls colocated companions in through their template, so
+// `+page.style.css` beside `+page.marko` is expected rather than a broken route.
+const markoCompanionReg = new RegExp(
+  `^[+](?:${markoFileTypes})\\.(?:style|component|component-browser|marko\\.d)\\.[^.]+$`,
+  "i",
+);
+
 function warnLookalike(message: string): void {
   // The cheat-sheet pointer is agent-gated; humans just see the convention.
   console.warn(`[marko-run] ${message}${agentRouteFixGuide()}`);
@@ -282,7 +290,7 @@ function warnLookalike(message: string): void {
 function warnNonRoutableLookalike(name: string, filePath: string): void {
   // `+page[mobile].marko` is arc's variant of a real `+page.marko`, not a break.
   const base = name.replace(bracketFlagReg, "");
-  if (RoutableFileRegex.test(base)) return;
+  if (RoutableFileRegex.test(base) || markoCompanionReg.test(base)) return;
 
   const relativeFilePath = path.relative(process.cwd(), filePath);
   if (base.includes("+")) {


### PR DESCRIPTION
Marko pulls colocated companion files in through their template, so a `+page.style.css` sitting next to `+page.marko` is expected — but the non-routable lookalike warning flagged it as a botched route.

The warning now skips files matching a Marko companion pattern (`.style.*`, `.component.*`, `.component-browser.*`, and generated `.marko.d.*`) on a routable Marko file type. Genuinely broken names like `+pge.marko`, `+server.js`, and `+wat.style.css` still warn.