### PR TITLE
fix: release QUERY method support as a patch while on 0.x

### DIFF
--- a/.changeset/query-http-verb.md
+++ b/.changeset/query-http-verb.md
@@ -1,5 +1,5 @@
 ---
-"@marko/run": minor
+"@marko/run": patch
 "@marko/run-explorer": patch
 ---
 


### PR DESCRIPTION
Changes the `query-http-verb` changeset's `@marko/run` bump from minor to patch. We're still on 0.x, so the QUERY method support should ship as a patch release; the changesets bot will regenerate the release PR as 0.11.10 with the entry under Patch Changes.